### PR TITLE
576 Clean up skipped tests on OC receiver 

### DIFF
--- a/receiver/opencensusreceiver/ocmetrics/opencensus_test.go
+++ b/receiver/opencensusreceiver/ocmetrics/opencensus_test.go
@@ -268,9 +268,7 @@ func TestExportProtocolViolations_nodelessFirstMessage(t *testing.T) {
 // metrics should be received and NEVER discarded.
 // See https://github.com/census-instrumentation/opencensus-service/issues/51
 func TestExportProtocolConformation_metricsInFirstMessage(t *testing.T) {
-	t.Skipf("Currently disabled, this test is flaky on Windows. Enable this test when the following are fixed:\nIssue %s\n",
-		"https://github.com/census-instrumentation/opencensus-service/issues/225",
-	)
+	// This test used to be flaky on Windows. Skip if errors pop up again
 
 	metricSink := new(exportertest.SinkMetricsExporter)
 


### PR DESCRIPTION
**Link to tracking Issue:** [#576](https://github.com/open-telemetry/opentelemetry-collector/issues/576)

**Description:** 
This PR aims to close issue [#576](https://github.com/open-telemetry/opentelemetry-collector/issues/576).

* `TestAcceptAllGRPCProtoAffiliatedContentTypes`: Removing this test since it's been two years since its been inactive and there is still no way to flush all written traces. As per discussion [here](https://github.com/open-telemetry/opentelemetry-collector/issues/576#issuecomment-693106883) and in Sept Wed 16 2020's Collector SIG meeting, there was agreement that this test could be removed since fixing it is costly enough to not be worth the effort.

* `TestExportProtocolConformation_metricsInFirstMessage:  Re-enabling this as it is now working on Windows. Tested this on Windows 10 with the following logs, but left a comment noting the test used to be flaky and to disable it if it starts breaking again 

```
C:\opentelemetry-collector-master\opentelemetry-collector-master\receiver\opencensusreceiver\ocmetrics>go test -v -race -run TestExportProtocolConformation_metricsInFirstMessage
=== RUN   TestExportProtocolConformation_metricsInFirstMessage
--- PASS: TestExportProtocolConformation_metricsInFirstMessage (0.11s)
PASS
ok      go.opentelemetry.io/collector/receiver/opencensusreceiver/ocmetrics     1.189s

C:\opentelemetry-collector-master\opentelemetry-collector-master\receiver\opencensusreceiver\ocmetrics>go test -v -race -run TestExportProtocolConformation_metricsInFirstMessage
=== RUN   TestExportProtocolConformation_metricsInFirstMessage
--- PASS: TestExportProtocolConformation_metricsInFirstMessage (0.11s)
PASS
ok      go.opentelemetry.io/collector/receiver/opencensusreceiver/ocmetrics     1.185s

C:\opentelemetry-collector-master\opentelemetry-collector-master\receiver\opencensusreceiver\ocmetrics>go test -v -race -run TestExportProtocolConformation_metricsInFirstMessage
=== RUN   TestExportProtocolConformation_metricsInFirstMessage
--- PASS: TestExportProtocolConformation_metricsInFirstMessage (0.11s)
PASS
ok      go.opentelemetry.io/collector/receiver/opencensusreceiver/ocmetrics     1.195s

C:\opentelemetry-collector-master\opentelemetry-collector-master\receiver\opencensusreceiver\ocmetrics>go test -v -race -run TestExportProtocolConformation_metricsInFirstMessage
=== RUN   TestExportProtocolConformation_metricsInFirstMessage
--- PASS: TestExportProtocolConformation_metricsInFirstMessage (0.11s)
PASS
ok      go.opentelemetry.io/collector/receiver/opencensusreceiver/ocmetrics     1.182s
``` 

* `TestReceiver_endToEnd` has already been resolved in some other unrelated issue.