### PR TITLE
Convert resource attributes to labels in prometheus remote write exporter

### DIFF
--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -32,6 +32,7 @@ import (
 
 	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/consumer/pdata"
+	common "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/common/v1"
 	otlp "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/metrics/v1"
 )
 
@@ -93,6 +94,10 @@ func (prwe *PrwExporter) PushMetrics(ctx context.Context, md pdata.Metrics) (int
 			if resourceMetric == nil {
 				continue
 			}
+			resourceAttributes, err := convertResourceAttributesToLabels(resourceMetric)
+			if err != nil {
+				errs = append(errs, err)
+			}
 			// TODO: add resource attributes as labels, probably in next PR
 			for _, instrumentationMetrics := range resourceMetric.InstrumentationLibraryMetrics {
 				if instrumentationMetrics == nil {
@@ -113,12 +118,12 @@ func (prwe *PrwExporter) PushMetrics(ctx context.Context, md pdata.Metrics) (int
 					// handle individual metric based on type
 					switch metric.Data.(type) {
 					case *otlp.Metric_DoubleSum, *otlp.Metric_IntSum, *otlp.Metric_DoubleGauge, *otlp.Metric_IntGauge:
-						if err := prwe.handleScalarMetric(tsMap, metric); err != nil {
+						if err := prwe.handleScalarMetric(tsMap, metric, resourceAttributes); err != nil {
 							dropped++
 							errs = append(errs, err)
 						}
 					case *otlp.Metric_DoubleHistogram, *otlp.Metric_IntHistogram:
-						if err := prwe.handleHistogramMetric(tsMap, metric); err != nil {
+						if err := prwe.handleHistogramMetric(tsMap, metric, resourceAttributes); err != nil {
 							dropped++
 							errs = append(errs, err)
 						}
@@ -146,7 +151,7 @@ func (prwe *PrwExporter) PushMetrics(ctx context.Context, md pdata.Metrics) (int
 // handleScalarMetric processes data points in a single OTLP scalar metric by adding the each point as a Sample into
 // its corresponding TimeSeries in tsMap.
 // tsMap and metric cannot be nil, and metric must have a non-nil descriptor
-func (prwe *PrwExporter) handleScalarMetric(tsMap map[string]*prompb.TimeSeries, metric *otlp.Metric) error {
+func (prwe *PrwExporter) handleScalarMetric(tsMap map[string]*prompb.TimeSeries, metric *otlp.Metric, resourceAttributes []*common.StringKeyValue) error {
 
 	switch metric.Data.(type) {
 	// int points
@@ -155,28 +160,28 @@ func (prwe *PrwExporter) handleScalarMetric(tsMap map[string]*prompb.TimeSeries,
 			return fmt.Errorf("nil data point. %s is dropped", metric.GetName())
 		}
 		for _, pt := range metric.GetDoubleGauge().GetDataPoints() {
-			addSingleDoubleDataPoint(pt, metric, prwe.namespace, tsMap)
+			addSingleDoubleDataPoint(pt, metric, prwe.namespace, tsMap, resourceAttributes)
 		}
 	case *otlp.Metric_IntGauge:
 		if metric.GetIntGauge().GetDataPoints() == nil {
 			return fmt.Errorf("nil data point. %s is dropped", metric.GetName())
 		}
 		for _, pt := range metric.GetIntGauge().GetDataPoints() {
-			addSingleIntDataPoint(pt, metric, prwe.namespace, tsMap)
+			addSingleIntDataPoint(pt, metric, prwe.namespace, tsMap, resourceAttributes)
 		}
 	case *otlp.Metric_DoubleSum:
 		if metric.GetDoubleSum().GetDataPoints() == nil {
 			return fmt.Errorf("nil data point. %s is dropped", metric.GetName())
 		}
 		for _, pt := range metric.GetDoubleSum().GetDataPoints() {
-			addSingleDoubleDataPoint(pt, metric, prwe.namespace, tsMap)
+			addSingleDoubleDataPoint(pt, metric, prwe.namespace, tsMap, resourceAttributes)
 		}
 	case *otlp.Metric_IntSum:
 		if metric.GetIntSum().GetDataPoints() == nil {
 			return fmt.Errorf("nil data point. %s is dropped", metric.GetName())
 		}
 		for _, pt := range metric.GetIntSum().GetDataPoints() {
-			addSingleIntDataPoint(pt, metric, prwe.namespace, tsMap)
+			addSingleIntDataPoint(pt, metric, prwe.namespace, tsMap, resourceAttributes)
 		}
 	}
 	return nil
@@ -185,7 +190,7 @@ func (prwe *PrwExporter) handleScalarMetric(tsMap map[string]*prompb.TimeSeries,
 // handleHistogramMetric processes data points in a single OTLP histogram metric by mapping the sum, count and each
 // bucket of every data point as a Sample, and adding each Sample to its corresponding TimeSeries.
 // tsMap and metric cannot be nil.
-func (prwe *PrwExporter) handleHistogramMetric(tsMap map[string]*prompb.TimeSeries, metric *otlp.Metric) error {
+func (prwe *PrwExporter) handleHistogramMetric(tsMap map[string]*prompb.TimeSeries, metric *otlp.Metric, resourceAttributes []*common.StringKeyValue) error {
 
 	switch metric.Data.(type) {
 	case *otlp.Metric_IntHistogram:
@@ -193,14 +198,14 @@ func (prwe *PrwExporter) handleHistogramMetric(tsMap map[string]*prompb.TimeSeri
 			return fmt.Errorf("nil data point. %s is dropped", metric.GetName())
 		}
 		for _, pt := range metric.GetIntHistogram().GetDataPoints() {
-			addSingleIntHistogramDataPoint(pt, metric, prwe.namespace, tsMap)
+			addSingleIntHistogramDataPoint(pt, metric, prwe.namespace, tsMap, resourceAttributes)
 		}
 	case *otlp.Metric_DoubleHistogram:
 		if metric.GetDoubleHistogram().GetDataPoints() == nil {
 			return fmt.Errorf("nil data point. %s is dropped", metric.GetName())
 		}
 		for _, pt := range metric.GetDoubleHistogram().GetDataPoints() {
-			addSingleDoubleHistogramDataPoint(pt, metric, prwe.namespace, tsMap)
+			addSingleDoubleHistogramDataPoint(pt, metric, prwe.namespace, tsMap, resourceAttributes)
 		}
 	}
 	return nil

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -94,9 +94,13 @@ func (prwe *PrwExporter) PushMetrics(ctx context.Context, md pdata.Metrics) (int
 			if resourceMetric == nil {
 				continue
 			}
-			resourceAttributes, err := convertResourceAttributesToLabels(resourceMetric)
-			if err != nil {
-				errs = append(errs, err)
+			var resourceAttributes []*common.StringKeyValue
+			if resourceMetric.Resource != nil {
+				var err error
+				resourceAttributes, err = convertResourceAttributesToLabels(resourceMetric.Resource)
+				if err != nil {
+					errs = append(errs, err)
+				}
 			}
 			// TODO: add resource attributes as labels, probably in next PR
 			for _, instrumentationMetrics := range resourceMetric.InstrumentationLibraryMetrics {

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -102,7 +102,6 @@ func (prwe *PrwExporter) PushMetrics(ctx context.Context, md pdata.Metrics) (int
 					errs = append(errs, err)
 				}
 			}
-			// TODO: add resource attributes as labels, probably in next PR
 			for _, instrumentationMetrics := range resourceMetric.InstrumentationLibraryMetrics {
 				if instrumentationMetrics == nil {
 					continue

--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -159,19 +159,8 @@ func createLabelSet(labels []*common.StringKeyValue, resourceAttributes []*commo
 	// map ensures no duplicate label name
 	l := map[string]prompb.Label{}
 
-	for _, lb := range labels {
-		l[lb.Key] = prompb.Label{
-			Name:  sanitize(lb.Key),
-			Value: lb.Value,
-		}
-	}
-
 	for _, ra := range resourceAttributes {
 		name := ra.GetKey()
-		_, found := l[name]
-		if found {
-			log.Println("label " + name + " is overwritten by a resource attribute. Check if Prometheus reserved labels are used.")
-		}
 		// if a resource attribute starts with the reserved prefix, sanitize but preserve prefix
 		if name[:2] == "__" {
 			name = "__" + sanitize(name[2:])
@@ -181,6 +170,13 @@ func createLabelSet(labels []*common.StringKeyValue, resourceAttributes []*commo
 		l[ra.GetKey()] = prompb.Label{
 			Name:  name,
 			Value: ra.GetValue(),
+		}
+	}
+
+	for _, lb := range labels {
+		l[lb.Key] = prompb.Label{
+			Name:  sanitize(lb.Key),
+			Value: lb.Value,
 		}
 	}
 

--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -138,8 +138,8 @@ func convertResourceAttributesToLabels(resource *resource.Resource) ([]*common.S
 		case *common.AnyValue_IntValue:
 			newLabel.Value = strconv.FormatInt(attr.GetValue().GetIntValue(), 10)
 		case *common.AnyValue_DoubleValue:
-			// option 'G' formats floats with an exponent (eg. d.dddde±dd) for sufficiently large values
-			newLabel.Value = strconv.FormatFloat(attr.GetValue().GetDoubleValue(), 'G', -1, 64)
+			// option 'f' formats floats without an exponent (eg. ddd.dddd)
+			newLabel.Value = strconv.FormatFloat(attr.GetValue().GetDoubleValue(), 'f', -1, 64)
 		case *common.AnyValue_ArrayValue:
 			return nil, errors.New("Array value resource attribute cannot be converted to label")
 		case *common.AnyValue_KvlistValue:

--- a/exporter/prometheusremotewriteexporter/helper_test.go
+++ b/exporter/prometheusremotewriteexporter/helper_test.go
@@ -315,6 +315,13 @@ func Test_createLabelSet(t *testing.T) {
 			getPromLabels(label11, value11, label12, value12, resAttrLabel1, resAttrValue1, resAttrLabel2, resAttrValue2, strings.Replace(resAttrLabel3, dirty3, "_", 1), resAttrValue3),
 		},
 		{
+			"resource_attribute_overwritten_by_label",
+			lbs1,
+			resAttrsWithDupe,
+			[]string{},
+			getPromLabels(resAttrLabel4, value11, label12, value12, resAttrLabel1, resAttrValue1),
+		},
+		{
 			"all_input_types_with_dirtys_and_duplicates",
 			lbs1,
 			resAttrsWithDirty,

--- a/exporter/prometheusremotewriteexporter/testutil_test.go
+++ b/exporter/prometheusremotewriteexporter/testutil_test.go
@@ -21,6 +21,7 @@ import (
 
 	commonpb "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/common/v1"
 	otlp "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/metrics/v1"
+	resource "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/resource/v1"
 )
 
 var (
@@ -29,20 +30,27 @@ var (
 	msTime1 = int64(time1 / uint64(int64(time.Millisecond)/int64(time.Nanosecond)))
 	msTime2 = int64(time2 / uint64(int64(time.Millisecond)/int64(time.Nanosecond)))
 
-	label11 = "test_label11"
-	value11 = "test_value11"
-	label12 = "test_label12"
-	value12 = "test_value12"
-	label21 = "test_label21"
-	value21 = "test_value21"
-	label22 = "test_label22"
-	value22 = "test_value22"
-	label31 = "test_label31"
-	value31 = "test_value31"
-	label32 = "test_label32"
-	value32 = "test_value32"
-	dirty1  = "%"
-	dirty2  = "?"
+	label11       = "test_label11"
+	value11       = "test_value11"
+	label12       = "test_label12"
+	value12       = "test_value12"
+	label21       = "test_label21"
+	value21       = "test_value21"
+	label22       = "test_label22"
+	value22       = "test_value22"
+	label31       = "test_label31"
+	value31       = "test_value31"
+	label32       = "test_label32"
+	value32       = "test_value32"
+	dirty1        = "%"
+	dirty2        = "?"
+	dirty3        = "."
+	resAttrLabel1 = "test_resattr1"
+	resAttrValue1 = "test_resattrval1"
+	resAttrLabel2 = "__testresattr2__"
+	resAttrValue2 = "test_resattrval2"
+	resAttrLabel3 = "test.resattr3"
+	resAttrValue3 = "test_resattrval3"
 
 	intVal1   int64 = 1
 	intVal2   int64 = 2
@@ -55,6 +63,9 @@ var (
 
 	promLbs1 = getPromLabels(label11, value11, label12, value12)
 	promLbs2 = getPromLabels(label21, value21, label22, value22)
+
+	resAttrs          = getLabels(resAttrLabel1, resAttrValue1, resAttrLabel2, resAttrValue2)
+	resAttrsWithDirty = getLabels(resAttrLabel1, resAttrValue1, resAttrLabel2, resAttrValue2, resAttrLabel3, resAttrValue3)
 
 	lb1Sig = "-" + label11 + "-" + value11 + "-" + label12 + "-" + value12
 	lb2Sig = "-" + label21 + "-" + value21 + "-" + label22 + "-" + value22
@@ -73,6 +84,121 @@ var (
 	}
 	bounds  = []float64{0.1, 0.5, 0.99}
 	buckets = []uint64{1, 2, 3}
+
+	validStringValue = "valid_StringValue"
+	validIntValue    = "valid_IntValue"
+	validBoolValue   = "valid_BoolValue"
+	validDoubleValue = "valid_DoubleValue"
+
+	validResources = map[string]*resource.Resource{
+		validStringValue: {
+			Attributes: []*commonpb.KeyValue{
+				{
+					Key: resAttrLabel1,
+					Value: &commonpb.AnyValue{
+						Value: &commonpb.AnyValue_StringValue{
+							StringValue: resAttrValue1,
+						},
+					},
+				},
+			},
+			DroppedAttributesCount: 0,
+		},
+		validIntValue: {
+			Attributes: []*commonpb.KeyValue{
+				{
+					Key: resAttrLabel2,
+					Value: &commonpb.AnyValue{
+						Value: &commonpb.AnyValue_IntValue{
+							IntValue: 1,
+						},
+					},
+				},
+			},
+			DroppedAttributesCount: 0,
+		},
+		validBoolValue: {
+			Attributes: []*commonpb.KeyValue{
+				{
+					Key: resAttrLabel3,
+					Value: &commonpb.AnyValue{
+						Value: &commonpb.AnyValue_BoolValue{
+							BoolValue: false,
+						},
+					},
+				},
+			},
+			DroppedAttributesCount: 0,
+		},
+		validDoubleValue: {
+			Attributes: []*commonpb.KeyValue{
+				{
+					Key: resAttrLabel1,
+					Value: &commonpb.AnyValue{
+						Value: &commonpb.AnyValue_DoubleValue{
+							DoubleValue: 1.23,
+						},
+					},
+				},
+			},
+			DroppedAttributesCount: 0,
+		},
+	}
+
+	invalidArrayValue        = "invalid_ArrayValue"
+	invalidKvListValue       = "invalid_KvListValue"
+	invalidMissingAttributes = "invalid_MissingAttributes"
+
+	invalidResources = map[string]*resource.Resource{
+		invalidArrayValue: {
+			Attributes: []*commonpb.KeyValue{
+				{
+					Key: resAttrLabel1,
+					Value: &commonpb.AnyValue{
+						Value: &commonpb.AnyValue_ArrayValue{
+							ArrayValue: &commonpb.ArrayValue{
+								Values: []*commonpb.AnyValue{
+									{
+										Value: &commonpb.AnyValue_StringValue{
+											StringValue: resAttrValue1,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			DroppedAttributesCount: 0,
+		},
+		invalidKvListValue: {
+			Attributes: []*commonpb.KeyValue{
+				{
+					Key: resAttrLabel1,
+					Value: &commonpb.AnyValue{
+						Value: &commonpb.AnyValue_KvlistValue{
+							KvlistValue: &commonpb.KeyValueList{
+								Values: []*commonpb.KeyValue{
+									{
+										Key: resAttrValue2,
+										Value: &commonpb.AnyValue{
+											Value: &commonpb.AnyValue_StringValue{
+												StringValue: resAttrValue1,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			DroppedAttributesCount: 0,
+		},
+		invalidMissingAttributes: {
+			DroppedAttributesCount: 0,
+		},
+	}
 
 	validIntGauge        = "valid_IntGauge"
 	validDoubleGauge     = "valid_DoubleGauge"

--- a/exporter/prometheusremotewriteexporter/testutil_test.go
+++ b/exporter/prometheusremotewriteexporter/testutil_test.go
@@ -51,6 +51,8 @@ var (
 	resAttrValue2 = "test_resattrval2"
 	resAttrLabel3 = "test.resattr3"
 	resAttrValue3 = "test_resattrval3"
+	resAttrLabel4 = "test_label11"
+	resAttrValue4 = "test_resattrval4"
 
 	intVal1   int64 = 1
 	intVal2   int64 = 2
@@ -66,6 +68,7 @@ var (
 
 	resAttrs          = getLabels(resAttrLabel1, resAttrValue1, resAttrLabel2, resAttrValue2)
 	resAttrsWithDirty = getLabels(resAttrLabel1, resAttrValue1, resAttrLabel2, resAttrValue2, resAttrLabel3, resAttrValue3)
+	resAttrsWithDupe  = getLabels(resAttrLabel1, resAttrValue1, resAttrLabel4, resAttrValue4)
 
 	lb1Sig = "-" + label11 + "-" + value11 + "-" + label12 + "-" + value12
 	lb2Sig = "-" + label21 + "-" + value21 + "-" + label22 + "-" + value22


### PR DESCRIPTION
**Description:** 
Added missing functionality of converting resource attributes to labels in Prometheus Remote Write Exporter. 

Furthermore, this PR merges the ideas of a Prometheus "External Label" with OTLP "Resource Attributes". From my understanding an "external label" is a label customer's can add in Prometheus' global config's, and they are allowed to start with "\_\_" unlike regular labels. Since resource attributes to not appear to have any restrictions for starting with "\_\_", I believe it is safe to merge these concepts.

This solves issue https://github.com/open-telemetry/opentelemetry-collector/issues/1892 because customer's can specify cortex's "cluster" and "\_\_replica\_\_" labels using the `resourceprocessor`, which would be equivalent to the suggested way to do it on Cortex's website (using external labels: https://cortexmetrics.io/docs/production/ha-pair-handling/)

Also note that this PR is not as long as it seems, a lot of lines are test data

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector/issues/1892

**Testing:** 
Unit tests have been added, and manual testing by exporting to cortex has shown resource attributes successfully appear as labels with no differences in the metrics graphs, which is expected

**Documentation:**
No documentation has been added as this was missing, expected functionality
