### PR TITLE
added external label functionality to prw exporter

### DIFF
--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -9,6 +9,7 @@ The following settings are required:
 
 The following settings can be optionally configured:
 - `namespace`: prefix attached to each exported metric name.
+- `external_labels`: list of labels to be attached to each metric data point
 - `headers`: additional headers attached to each HTTP request. If `X-Prometheus-Remote-Write-Version` is set by user, its value must be `0.1.0`
 - `insecure` (default = false): whether to enable client transport security for the exporter's connection.
 - `ca_file`: path to the CA cert. For a client this verifies the server certificate. Should only be used if `insecure` is set to false.

--- a/exporter/prometheusremotewriteexporter/config.go
+++ b/exporter/prometheusremotewriteexporter/config.go
@@ -32,5 +32,13 @@ type Config struct {
 	// See: https://prometheus.io/docs/practices/naming/#metric-names
 	Namespace string `mapstructure:"namespace"`
 
+	ExternalLabels []ExternalLabel `mapstructure:"external_labels"`
+
 	HTTPClientSettings confighttp.HTTPClientSettings `mapstructure:",squash"`
+}
+
+// ExternalLabel defines a label key and value that is allowed to start with reserved prefix "__"
+type ExternalLabel struct {
+	Key   string `mapstructure:"key"`
+	Value string `mapstructure:"value"`
 }

--- a/exporter/prometheusremotewriteexporter/config_test.go
+++ b/exporter/prometheusremotewriteexporter/config_test.go
@@ -66,8 +66,8 @@ func Test_loadConfig(t *testing.T) {
 				MaxInterval:     1 * time.Minute,
 				MaxElapsedTime:  10 * time.Minute,
 			},
-			Namespace: "test-space",
-
+			Namespace:      "test-space",
+			ExternalLabels: []ExternalLabel{{Key: "key1", Value: "val1"}},
 			HTTPClientSettings: confighttp.HTTPClientSettings{
 				Endpoint: "localhost:8888",
 				TLSSetting: configtls.TLSClientSetting{

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -38,16 +38,17 @@ import (
 
 // PrwExporter converts OTLP metrics to Prometheus remote write TimeSeries and sends them to a remote endpoint
 type PrwExporter struct {
-	namespace   string
-	endpointURL *url.URL
-	client      *http.Client
-	wg          *sync.WaitGroup
-	closeChan   chan struct{}
+	namespace      string
+	externalLabels []ExternalLabel
+	endpointURL    *url.URL
+	client         *http.Client
+	wg             *sync.WaitGroup
+	closeChan      chan struct{}
 }
 
 // NewPrwExporter initializes a new PrwExporter instance and sets fields accordingly.
 // client parameter cannot be nil.
-func NewPrwExporter(namespace string, endpoint string, client *http.Client) (*PrwExporter, error) {
+func NewPrwExporter(namespace string, endpoint string, client *http.Client, externalLabels []ExternalLabel) (*PrwExporter, error) {
 
 	if client == nil {
 		return nil, errors.New("http client cannot be nil")
@@ -59,11 +60,12 @@ func NewPrwExporter(namespace string, endpoint string, client *http.Client) (*Pr
 	}
 
 	return &PrwExporter{
-		namespace:   namespace,
-		endpointURL: endpointURL,
-		client:      client,
-		wg:          new(sync.WaitGroup),
-		closeChan:   make(chan struct{}),
+		namespace:      namespace,
+		externalLabels: externalLabels,
+		endpointURL:    endpointURL,
+		client:         client,
+		wg:             new(sync.WaitGroup),
+		closeChan:      make(chan struct{}),
 	}, nil
 }
 
@@ -156,28 +158,28 @@ func (prwe *PrwExporter) handleScalarMetric(tsMap map[string]*prompb.TimeSeries,
 			return fmt.Errorf("nil data point. %s is dropped", metric.GetName())
 		}
 		for _, pt := range metric.GetDoubleGauge().GetDataPoints() {
-			addSingleDoubleDataPoint(pt, metric, prwe.namespace, tsMap)
+			addSingleDoubleDataPoint(pt, metric, prwe.namespace, tsMap, prwe.externalLabels)
 		}
 	case *otlp.Metric_IntGauge:
 		if metric.GetIntGauge().GetDataPoints() == nil {
 			return fmt.Errorf("nil data point. %s is dropped", metric.GetName())
 		}
 		for _, pt := range metric.GetIntGauge().GetDataPoints() {
-			addSingleIntDataPoint(pt, metric, prwe.namespace, tsMap)
+			addSingleIntDataPoint(pt, metric, prwe.namespace, tsMap, prwe.externalLabels)
 		}
 	case *otlp.Metric_DoubleSum:
 		if metric.GetDoubleSum().GetDataPoints() == nil {
 			return fmt.Errorf("nil data point. %s is dropped", metric.GetName())
 		}
 		for _, pt := range metric.GetDoubleSum().GetDataPoints() {
-			addSingleDoubleDataPoint(pt, metric, prwe.namespace, tsMap)
+			addSingleDoubleDataPoint(pt, metric, prwe.namespace, tsMap, prwe.externalLabels)
 		}
 	case *otlp.Metric_IntSum:
 		if metric.GetIntSum().GetDataPoints() == nil {
 			return fmt.Errorf("nil data point. %s is dropped", metric.GetName())
 		}
 		for _, pt := range metric.GetIntSum().GetDataPoints() {
-			addSingleIntDataPoint(pt, metric, prwe.namespace, tsMap)
+			addSingleIntDataPoint(pt, metric, prwe.namespace, tsMap, prwe.externalLabels)
 		}
 	}
 	return nil
@@ -194,14 +196,14 @@ func (prwe *PrwExporter) handleHistogramMetric(tsMap map[string]*prompb.TimeSeri
 			return fmt.Errorf("nil data point. %s is dropped", metric.GetName())
 		}
 		for _, pt := range metric.GetIntHistogram().GetDataPoints() {
-			addSingleIntHistogramDataPoint(pt, metric, prwe.namespace, tsMap)
+			addSingleIntHistogramDataPoint(pt, metric, prwe.namespace, tsMap, prwe.externalLabels)
 		}
 	case *otlp.Metric_DoubleHistogram:
 		if metric.GetDoubleHistogram().GetDataPoints() == nil {
 			return fmt.Errorf("nil data point. %s is dropped", metric.GetName())
 		}
 		for _, pt := range metric.GetDoubleHistogram().GetDataPoints() {
-			addSingleDoubleHistogramDataPoint(pt, metric, prwe.namespace, tsMap)
+			addSingleDoubleHistogramDataPoint(pt, metric, prwe.namespace, tsMap, prwe.externalLabels)
 		}
 	}
 	return nil

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -46,21 +46,24 @@ func Test_NewPrwExporter(t *testing.T) {
 		QueueSettings:      exporterhelper.QueueSettings{},
 		RetrySettings:      exporterhelper.RetrySettings{},
 		Namespace:          "",
+		ExternalLabels:     []ExternalLabel{},
 		HTTPClientSettings: confighttp.HTTPClientSettings{Endpoint: ""},
 	}
 	tests := []struct {
-		name        string
-		config      *Config
-		namespace   string
-		endpoint    string
-		client      *http.Client
-		returnError bool
+		name           string
+		config         *Config
+		namespace      string
+		endpoint       string
+		externalLabels []ExternalLabel
+		client         *http.Client
+		returnError    bool
 	}{
 		{
 			"invalid_URL",
 			config,
 			"test",
 			"invalid URL",
+			[]ExternalLabel{{Key: "Key1", Value: "Val1"}},
 			http.DefaultClient,
 			true,
 		},
@@ -69,6 +72,7 @@ func Test_NewPrwExporter(t *testing.T) {
 			config,
 			"test",
 			"http://some.url:9411/api/prom/push",
+			[]ExternalLabel{{Key: "Key1", Value: "Val1"}},
 			nil,
 			true,
 		},
@@ -77,6 +81,7 @@ func Test_NewPrwExporter(t *testing.T) {
 			config,
 			"test",
 			"http://some.url:9411/api/prom/push",
+			[]ExternalLabel{{Key: "Key1", Value: "Val1"}},
 			http.DefaultClient,
 			false,
 		},
@@ -84,7 +89,7 @@ func Test_NewPrwExporter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prwe, err := NewPrwExporter(tt.namespace, tt.endpoint, tt.client)
+			prwe, err := NewPrwExporter(tt.namespace, tt.endpoint, tt.client, tt.externalLabels)
 			if tt.returnError {
 				assert.Error(t, err)
 				return
@@ -92,6 +97,7 @@ func Test_NewPrwExporter(t *testing.T) {
 			require.NotNil(t, prwe)
 			assert.NotNil(t, prwe.namespace)
 			assert.NotNil(t, prwe.endpointURL)
+			assert.NotNil(t, prwe.externalLabels)
 			assert.NotNil(t, prwe.client)
 			assert.NotNil(t, prwe.closeChan)
 			assert.NotNil(t, prwe.wg)
@@ -220,7 +226,7 @@ func runExportPipeline(t *testing.T, ts *prompb.TimeSeries, endpoint *url.URL) e
 
 	HTTPClient := http.DefaultClient
 	// after this, instantiate a CortexExporter with the current HTTP client and endpoint set to passed in endpoint
-	prwe, err := NewPrwExporter("test", endpoint.String(), HTTPClient)
+	prwe, err := NewPrwExporter("test", endpoint.String(), HTTPClient, []ExternalLabel{})
 	if err != nil {
 		return err
 	}
@@ -652,7 +658,7 @@ func Test_PushMetrics(t *testing.T) {
 			// c, err := config.HTTPClientSettings.ToClient()
 			// assert.Nil(t, err)
 			c := http.DefaultClient
-			prwe, nErr := NewPrwExporter(config.Namespace, serverURL.String(), c)
+			prwe, nErr := NewPrwExporter(config.Namespace, serverURL.String(), c, []ExternalLabel{})
 			require.NoError(t, nErr)
 			numDroppedTimeSeries, err := prwe.PushMetrics(context.Background(), *tt.md)
 			assert.Equal(t, tt.numDroppedTimeSeries, numDroppedTimeSeries)

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -99,7 +99,7 @@ func createDefaultConfig() configmodels.Exporter {
 func validateLabelConfig(cfg *Config) error {
 	for _, elem := range cfg.ExternalLabels {
 		if elem.Key == "" || elem.Value == "" {
-			return fmt.Errorf("Prometheus Remote Write: external labels configuration contains an empty key or value")
+			return fmt.Errorf("prometheus remote write: external labels configuration contains an empty key or value")
 		}
 	}
 
@@ -107,7 +107,7 @@ func validateLabelConfig(cfg *Config) error {
 	for _, elem := range cfg.ExternalLabels {
 		_, value := keys[elem.Key]
 		if value {
-			return fmt.Errorf("Prometheus Remote Write: external labels configuration contains duplicate keys")
+			return fmt.Errorf("prometheus remote write: external labels configuration contains duplicate keys")
 		}
 		keys[elem.Key] = true
 	}

--- a/exporter/prometheusremotewriteexporter/factory_test.go
+++ b/exporter/prometheusremotewriteexporter/factory_test.go
@@ -97,11 +97,11 @@ func Test_validateLabelConfig(t *testing.T) {
 	validConfigWithLabels.ExternalLabels = append(validConfigWithLabels.ExternalLabels, ExternalLabel{Key: "key1", Value: "val1"})
 
 	invalidConfigWithLabels := createDefaultConfig().(*Config)
-	invalidConfigWithLabels.ExternalLabels = append(validConfigWithLabels.ExternalLabels, ExternalLabel{Key: "", Value: "val1"})
+	invalidConfigWithLabels.ExternalLabels = append(invalidConfigWithLabels.ExternalLabels, ExternalLabel{Key: "", Value: "val1"})
 
 	invalidConfigWithDupeLabels := createDefaultConfig().(*Config)
-	invalidConfigWithDupeLabels.ExternalLabels = append(validConfigWithLabels.ExternalLabels, ExternalLabel{Key: "key1", Value: "val1"})
-	invalidConfigWithDupeLabels.ExternalLabels = append(validConfigWithLabels.ExternalLabels, ExternalLabel{Key: "key1", Value: "val2"})
+	invalidConfigWithDupeLabels.ExternalLabels = append(invalidConfigWithDupeLabels.ExternalLabels, ExternalLabel{Key: "key1", Value: "val1"})
+	invalidConfigWithDupeLabels.ExternalLabels = append(invalidConfigWithDupeLabels.ExternalLabels, ExternalLabel{Key: "key1", Value: "val2"})
 
 	tests := []struct {
 		name        string

--- a/exporter/prometheusremotewriteexporter/factory_test.go
+++ b/exporter/prometheusremotewriteexporter/factory_test.go
@@ -89,3 +89,51 @@ func Test_createMetricsExporter(t *testing.T) {
 		})
 	}
 }
+
+func Test_validateLabelConfig(t *testing.T) {
+	validConfig := createDefaultConfig().(*Config)
+
+	validConfigWithLabels := createDefaultConfig().(*Config)
+	validConfigWithLabels.ExternalLabels = append(validConfigWithLabels.ExternalLabels, ExternalLabel{Key: "key1", Value: "val1"})
+
+	invalidConfigWithLabels := createDefaultConfig().(*Config)
+	invalidConfigWithLabels.ExternalLabels = append(validConfigWithLabels.ExternalLabels, ExternalLabel{Key: "", Value: "val1"})
+
+	invalidConfigWithDupeLabels := createDefaultConfig().(*Config)
+	invalidConfigWithDupeLabels.ExternalLabels = append(validConfigWithLabels.ExternalLabels, ExternalLabel{Key: "key1", Value: "val1"})
+	invalidConfigWithDupeLabels.ExternalLabels = append(validConfigWithLabels.ExternalLabels, ExternalLabel{Key: "key1", Value: "val2"})
+
+	tests := []struct {
+		name        string
+		cfg         *Config
+		returnError bool
+	}{
+		{"success_case_no_labels",
+			validConfig,
+			false,
+		},
+		{"success_case_with_labels",
+			validConfigWithLabels,
+			false,
+		},
+		{"fail_case_empty_label",
+			invalidConfigWithLabels,
+			true,
+		},
+		{"fail_case_dupe_label",
+			invalidConfigWithDupeLabels,
+			true,
+		},
+	}
+	// run tests
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLabelConfig(tt.cfg)
+			if tt.returnError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -122,10 +122,24 @@ func timeSeriesSignature(metric *otlp.Metric, labels *[]prompb.Label) string {
 // createLabelSet creates a slice of Cortex Label with OTLP labels and paris of string values.
 // Unpaired string value is ignored. String pairs overwrites OTLP labels if collision happens, and the overwrite is
 // logged. Resultant label names are sanitized.
-func createLabelSet(labels []common.StringKeyValue, extras ...string) []prompb.Label {
+func createLabelSet(labels []common.StringKeyValue, externalLabels []ExternalLabel, extras ...string) []prompb.Label {
 
 	// map ensures no duplicate label name
 	l := map[string]prompb.Label{}
+
+	for _, el := range externalLabels {
+		name := el.Key
+		// The reserved prefix "__" is allowed in an external label
+		if name[:2] == "__" {
+			name = "__" + sanitize(name[2:])
+		} else {
+			name = sanitize(name)
+		}
+		l[el.Key] = prompb.Label{
+			Name:  name,
+			Value: el.Value,
+		}
+	}
 
 	for _, lb := range labels {
 		l[lb.Key] = prompb.Label{
@@ -277,13 +291,13 @@ func getTypeString(metric *otlp.Metric) string {
 // addSingleDoubleDataPoint converts the metric value stored in pt to a Prometheus sample, and add the sample
 // to its corresponding time series in tsMap
 func addSingleDoubleDataPoint(pt *otlp.DoubleDataPoint, metric *otlp.Metric, namespace string,
-	tsMap map[string]*prompb.TimeSeries) {
+	tsMap map[string]*prompb.TimeSeries, externalLabels []ExternalLabel) {
 	if pt == nil {
 		return
 	}
 	// create parameters for addSample
 	name := getPromMetricName(metric, namespace)
-	labels := createLabelSet(pt.GetLabels(), nameStr, name)
+	labels := createLabelSet(pt.GetLabels(), externalLabels, nameStr, name)
 	sample := &prompb.Sample{
 		Value: pt.Value,
 		// convert ns to ms
@@ -295,13 +309,13 @@ func addSingleDoubleDataPoint(pt *otlp.DoubleDataPoint, metric *otlp.Metric, nam
 // addSingleIntDataPoint converts the metric value stored in pt to a Prometheus sample, and add the sample
 // to its corresponding time series in tsMap
 func addSingleIntDataPoint(pt *otlp.IntDataPoint, metric *otlp.Metric, namespace string,
-	tsMap map[string]*prompb.TimeSeries) {
+	tsMap map[string]*prompb.TimeSeries, externalLabels []ExternalLabel) {
 	if pt == nil {
 		return
 	}
 	// create parameters for addSample
 	name := getPromMetricName(metric, namespace)
-	labels := createLabelSet(pt.GetLabels(), nameStr, name)
+	labels := createLabelSet(pt.GetLabels(), externalLabels, nameStr, name)
 	sample := &prompb.Sample{
 		Value: float64(pt.Value),
 		// convert ns to ms
@@ -313,7 +327,7 @@ func addSingleIntDataPoint(pt *otlp.IntDataPoint, metric *otlp.Metric, namespace
 // addSingleIntHistogramDataPoint converts pt to 2 + min(len(ExplicitBounds), len(BucketCount)) + 1 samples. It
 // ignore extra buckets if len(ExplicitBounds) > len(BucketCounts)
 func addSingleIntHistogramDataPoint(pt *otlp.IntHistogramDataPoint, metric *otlp.Metric, namespace string,
-	tsMap map[string]*prompb.TimeSeries) {
+	tsMap map[string]*prompb.TimeSeries, externalLabels []ExternalLabel) {
 	if pt == nil {
 		return
 	}
@@ -326,7 +340,7 @@ func addSingleIntHistogramDataPoint(pt *otlp.IntHistogramDataPoint, metric *otlp
 		Timestamp: time,
 	}
 
-	sumlabels := createLabelSet(pt.GetLabels(), nameStr, baseName+sumStr)
+	sumlabels := createLabelSet(pt.GetLabels(), externalLabels, nameStr, baseName+sumStr)
 	addSample(tsMap, sum, sumlabels, metric)
 
 	// treat count as a sample in an individual TimeSeries
@@ -334,7 +348,7 @@ func addSingleIntHistogramDataPoint(pt *otlp.IntHistogramDataPoint, metric *otlp
 		Value:     float64(pt.GetCount()),
 		Timestamp: time,
 	}
-	countlabels := createLabelSet(pt.GetLabels(), nameStr, baseName+countStr)
+	countlabels := createLabelSet(pt.GetLabels(), externalLabels, nameStr, baseName+countStr)
 	addSample(tsMap, count, countlabels, metric)
 
 	// count for +Inf bound
@@ -351,7 +365,7 @@ func addSingleIntHistogramDataPoint(pt *otlp.IntHistogramDataPoint, metric *otlp
 			Timestamp: time,
 		}
 		boundStr := strconv.FormatFloat(bound, 'f', -1, 64)
-		labels := createLabelSet(pt.GetLabels(), nameStr, baseName+bucketStr, leStr, boundStr)
+		labels := createLabelSet(pt.GetLabels(), externalLabels, nameStr, baseName+bucketStr, leStr, boundStr)
 		addSample(tsMap, bucket, labels, metric)
 
 		totalCount += bk
@@ -361,14 +375,14 @@ func addSingleIntHistogramDataPoint(pt *otlp.IntHistogramDataPoint, metric *otlp
 		Value:     float64(totalCount),
 		Timestamp: time,
 	}
-	infLabels := createLabelSet(pt.GetLabels(), nameStr, baseName+bucketStr, leStr, pInfStr)
+	infLabels := createLabelSet(pt.GetLabels(), externalLabels, nameStr, baseName+bucketStr, leStr, pInfStr)
 	addSample(tsMap, infBucket, infLabels, metric)
 }
 
 // addSingleDoubleHistogramDataPoint converts pt to 2 + min(len(ExplicitBounds), len(BucketCount)) + 1 samples. It
 // ignore extra buckets if len(ExplicitBounds) > len(BucketCounts)
 func addSingleDoubleHistogramDataPoint(pt *otlp.DoubleHistogramDataPoint, metric *otlp.Metric, namespace string,
-	tsMap map[string]*prompb.TimeSeries) {
+	tsMap map[string]*prompb.TimeSeries, externalLabels []ExternalLabel) {
 	if pt == nil {
 		return
 	}
@@ -381,7 +395,7 @@ func addSingleDoubleHistogramDataPoint(pt *otlp.DoubleHistogramDataPoint, metric
 		Timestamp: time,
 	}
 
-	sumlabels := createLabelSet(pt.GetLabels(), nameStr, baseName+sumStr)
+	sumlabels := createLabelSet(pt.GetLabels(), externalLabels, nameStr, baseName+sumStr)
 	addSample(tsMap, sum, sumlabels, metric)
 
 	// treat count as a sample in an individual TimeSeries
@@ -389,7 +403,7 @@ func addSingleDoubleHistogramDataPoint(pt *otlp.DoubleHistogramDataPoint, metric
 		Value:     float64(pt.GetCount()),
 		Timestamp: time,
 	}
-	countlabels := createLabelSet(pt.GetLabels(), nameStr, baseName+countStr)
+	countlabels := createLabelSet(pt.GetLabels(), externalLabels, nameStr, baseName+countStr)
 	addSample(tsMap, count, countlabels, metric)
 
 	// count for +Inf bound
@@ -406,7 +420,7 @@ func addSingleDoubleHistogramDataPoint(pt *otlp.DoubleHistogramDataPoint, metric
 			Timestamp: time,
 		}
 		boundStr := strconv.FormatFloat(bound, 'f', -1, 64)
-		labels := createLabelSet(pt.GetLabels(), nameStr, baseName+bucketStr, leStr, boundStr)
+		labels := createLabelSet(pt.GetLabels(), externalLabels, nameStr, baseName+bucketStr, leStr, boundStr)
 		addSample(tsMap, bucket, labels, metric)
 
 		totalCount += bk
@@ -416,6 +430,6 @@ func addSingleDoubleHistogramDataPoint(pt *otlp.DoubleHistogramDataPoint, metric
 		Value:     float64(totalCount),
 		Timestamp: time,
 	}
-	infLabels := createLabelSet(pt.GetLabels(), nameStr, baseName+bucketStr, leStr, pInfStr)
+	infLabels := createLabelSet(pt.GetLabels(), externalLabels, nameStr, baseName+bucketStr, leStr, pInfStr)
 	addSample(tsMap, infBucket, infLabels, metric)
 }

--- a/exporter/prometheusremotewriteexporter/helper_test.go
+++ b/exporter/prometheusremotewriteexporter/helper_test.go
@@ -184,31 +184,36 @@ func Test_timeSeriesSignature(t *testing.T) {
 // collision happens. It does not check whether labels are not sorted
 func Test_createLabelSet(t *testing.T) {
 	tests := []struct {
-		name   string
-		orig   []common.StringKeyValue
-		extras []string
-		want   []prompb.Label
+		name           string
+		orig           []common.StringKeyValue
+		externalLabels []ExternalLabel
+		extras         []string
+		want           []prompb.Label
 	}{
 		{
 			"labels_clean",
 			lbs1,
+			[]ExternalLabel{},
 			[]string{label31, value31, label32, value32},
 			getPromLabels(label11, value11, label12, value12, label31, value31, label32, value32),
 		},
 		{
 			"labels_duplicate_in_extras",
 			lbs1,
+			[]ExternalLabel{},
 			[]string{label11, value31},
 			getPromLabels(label11, value31, label12, value12),
 		},
 		{
 			"labels_dirty",
 			lbs1Dirty,
+			[]ExternalLabel{},
 			[]string{label31 + dirty1, value31, label32, value32},
 			getPromLabels(label11+"_", value11, "key_"+label12, value12, label31+"_", value31, label32, value32),
 		},
 		{
 			"no_original_case",
+			nil,
 			nil,
 			[]string{label31, value31, label32, value32},
 			getPromLabels(label31, value31, label32, value32),
@@ -216,20 +221,36 @@ func Test_createLabelSet(t *testing.T) {
 		{
 			"empty_extra_case",
 			lbs1,
+			[]ExternalLabel{},
 			[]string{"", ""},
 			getPromLabels(label11, value11, label12, value12, "", ""),
 		},
 		{
 			"single_left_over_case",
 			lbs1,
+			[]ExternalLabel{},
 			[]string{label31, value31, label32},
 			getPromLabels(label11, value11, label12, value12, label31, value31),
+		},
+		{
+			"valid_external_labels",
+			lbs1,
+			exlbs1,
+			[]string{label31, value31, label32, value32},
+			getPromLabels(label11, value11, label12, value12, label41, value41, label31, value31, label32, value32),
+		},
+		{
+			"overwritten_external_labels",
+			lbs1,
+			exlbs2,
+			[]string{label31, value31, label32, value32},
+			getPromLabels(label11, value11, label12, value12, label31, value31, label32, value32),
 		},
 	}
 	// run tests
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.ElementsMatch(t, tt.want, createLabelSet(tt.orig, tt.extras...))
+			assert.ElementsMatch(t, tt.want, createLabelSet(tt.orig, tt.externalLabels, tt.extras...))
 		})
 	}
 }

--- a/exporter/prometheusremotewriteexporter/testdata/config.yaml
+++ b/exporter/prometheusremotewriteexporter/testdata/config.yaml
@@ -23,6 +23,9 @@ exporters:
         headers:
             Prometheus-Remote-Write-Version: "0.1.0"
             X-Scope-OrgID: 234
+        external_labels:
+            - key: key1
+              value: val1
 
 service:
     pipelines:

--- a/exporter/prometheusremotewriteexporter/testutil_test.go
+++ b/exporter/prometheusremotewriteexporter/testutil_test.go
@@ -41,6 +41,8 @@ var (
 	value31 = "test_value31"
 	label32 = "test_label32"
 	value32 = "test_value32"
+	label41 = "__test_label41__"
+	value41 = "test_value41"
 	dirty1  = "%"
 	dirty2  = "?"
 
@@ -52,6 +54,9 @@ var (
 	lbs1      = getLabels(label11, value11, label12, value12)
 	lbs2      = getLabels(label21, value21, label22, value22)
 	lbs1Dirty = getLabels(label11+dirty1, value11, dirty2+label12, value12)
+
+	exlbs1 = []ExternalLabel{{Key: label41, Value: value41}}
+	exlbs2 = []ExternalLabel{{Key: label11, Value: value41}}
 
 	promLbs1 = getPromLabels(label11, value11, label12, value12)
 	promLbs2 = getPromLabels(label21, value21, label22, value22)


### PR DESCRIPTION
**Description:** 
This PR adds the concept of Prometheus "external labels" to the Prometheus Remote Write Exporter. These labels must be kept isolated from OTLP metric data point labels because they do not undergo the same type of sanitization. The difference is external labels are allowed to start with "\_\_". This satisfies the use case of Cortex HA deduplication and hence resolves the linked issue. 

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/1892

**Testing:** 
Unit test cases have been added wherever changes were made and manual testing was done to verify Cortex HA deduplication and that nothing changed in metric graphs other than labels.

**Documentation:**
The example configuration in `testdata/config.yaml` demonstrates how to use the external label config
