### PR TITLE
Add logging for summary datapoint

### DIFF
--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -106,6 +106,9 @@ func (b *logDataBuffer) logMetricDataPoints(m pdata.Metric) {
 		data := m.DoubleHistogram()
 		b.logEntry("     -> AggregationTemporality: %s", data.AggregationTemporality().String())
 		b.logDoubleHistogramDataPoints(data.DataPoints())
+	case pdata.MetricDataTypeDoubleSummary:
+		data := m.DoubleSummary()
+		b.logDoubleSummaryDataPoints(data.DataPoints())
 	}
 }
 
@@ -199,6 +202,29 @@ func (b *logDataBuffer) logIntHistogramDataPoints(ps pdata.IntHistogramDataPoint
 			for j, bucket := range buckets {
 				b.logEntry("Buckets #%d, Count: %d", j, bucket)
 			}
+		}
+	}
+}
+
+func (b *logDataBuffer) logDoubleSummaryDataPoints(ps pdata.DoubleSummaryDataPointSlice) {
+	for i := 0; i < ps.Len(); i++ {
+		p := ps.At(i)
+		if p.IsNil() {
+			continue
+		}
+
+		b.logEntry("SummaryDataPoints #%d", i)
+		b.logDataPointLabels(p.LabelsMap())
+
+		b.logEntry("StartTime: %d", p.StartTime())
+		b.logEntry("Timestamp: %d", p.Timestamp())
+		b.logEntry("Count: %d", p.Count())
+		b.logEntry("Sum: %f", p.Sum())
+
+		quantiles := p.QuantileValues()
+		for i := 0; i < quantiles.Len(); i++ {
+			quantile := quantiles.At(i)
+			b.logEntry("QuantileValue #%d: Quantile %f, Value %f", i, quantile.Quantile(), quantile.Value())
 		}
 	}
 }


### PR DESCRIPTION
**Description:** 
This issue adds logging for the summary datapoint in the logging exporter. This is primarily added for testing purposes.

**Link to tracking Issue:** `https://github.com/open-telemetry/opentelemetry-collector/issues/1638`

**Resulting Logs**

```
Metric #38
Descriptor:
     -> Name: rpc_durations_seconds
     -> Description: RPC latency distributions.
     -> Unit: s
     -> DataType: DoubleSummary
SummaryDataPoints #0
Data point labels:
     -> Namespace: rpc-app
     -> Service: rpc-app-service
     -> app: rpc-app
     -> container_name: rpc-app-cont
     -> service: exponential
StartTime: 1604691204093000000
Timestamp: 1604691234093000000
Count: 410
Sum: 0.000414
QuantileValue #0: Quantile 0.500000, Value 0.000001
QuantileValue #1: Quantile 0.900000, Value 0.000002
QuantileValue #2: Quantile 0.990000, Value 0.000005
```
