### PR TITLE
Add batched exports to the Prometheus Remote Write Exporter

### DIFF
--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -143,9 +143,9 @@ func (prwe *PrwExporter) PushMetrics(ctx context.Context, md pdata.Metrics) (int
 			}
 		}
 
-		if err := prwe.export(ctx, tsMap); err != nil {
+		if exportErrs := prwe.export(ctx, tsMap); len(exportErrs) != 0 {
 			dropped = md.MetricCount()
-			errs = append(errs, consumererror.Permanent(err))
+			errs = append(errs, ...exportErrs)
 		}
 
 		if dropped != 0 {
@@ -252,13 +252,33 @@ func (prwe *PrwExporter) handleSummaryMetric(tsMap map[string]*prompb.TimeSeries
 }
 
 // export sends a Snappy-compressed WriteRequest containing TimeSeries to a remote write endpoint in order
-func (prwe *PrwExporter) export(ctx context.Context, tsMap map[string]*prompb.TimeSeries) error {
-	// Calls the helper function to convert the TsMap to the desired format
-	req, err := wrapTimeSeries(tsMap)
+func (prwe *PrwExporter) export(ctx context.Context, tsMap map[string]*prompb.TimeSeries) []error {
+	var errs []error
+	// Calls the helper function to convert and batch the TsMap to the desired format
+	requests, err := wrapAndBatchTimeSeries(tsMap)
 	if err != nil {
-		return consumererror.Permanent(err)
+		errs = append(errs, consumererror.Permanent(err))
 	}
 
+	var wg sync.WaitGroup
+
+	// performs the batched requests concurrently
+	for _, request := range requests {
+		wg.Add(1)
+		go func(req *prompb.WriteRequest) {
+			err := prwe.execute(ctx, req)
+			if err != nil {
+				errs = append(errs, consumererror.Permanent(err))
+			}
+			wg.Done()
+		}(request)
+	}
+	wg.Wait()
+
+	return errs
+}
+
+func (prwe *PrwExporter) execute(ctx context.Context, req *prompb.WriteRequest) error {
 	// Uses proto.Marshal to convert the WriteRequest into bytes array
 	data, err := proto.Marshal(req)
 	if err != nil {

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -143,7 +143,7 @@ func (prwe *PrwExporter) PushMetrics(ctx context.Context, md pdata.Metrics) (int
 			}
 		}
 
-		if exportErrors := prwe.export(ctx, tsMap); exportErrors != nil {
+		if exportErrors := prwe.export(ctx, tsMap); len(exportErrors) != 0 {
 			dropped = md.MetricCount()
 			errs = append(errs, exportErrors...)
 		}
@@ -264,7 +264,6 @@ func (prwe *PrwExporter) export(ctx context.Context, tsMap map[string]*prompb.Ti
 	var wg sync.WaitGroup
 	var mtx sync.Mutex
 
-	// performs the batched requests concurrently
 	for _, request := range requests {
 		wg.Add(1)
 		go func(req *prompb.WriteRequest) {

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -269,11 +269,10 @@ func (prwe *PrwExporter) export(ctx context.Context, tsMap map[string]*prompb.Ti
 
 	for i := 0; i < numOfRequests; i += maxConcurrentRequests {
 		var wg sync.WaitGroup
-		fmt.Println("next batch of requests")
+
 		for k := i; k < int(math.Min(float64(i+maxConcurrentRequests), float64(numOfRequests))); k++ {
 			wg.Add(1)
 			go func(i int, req *prompb.WriteRequest) {
-				fmt.Println("making request " + fmt.Sprintf("%d", i))
 				requestError := prwe.execute(ctx, req)
 				if requestError != nil {
 					mu.Lock()
@@ -283,6 +282,7 @@ func (prwe *PrwExporter) export(ctx context.Context, tsMap map[string]*prompb.Ti
 				wg.Done()
 			}(k, requests[k])
 		}
+
 		wg.Wait()
 	}
 

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -257,7 +257,7 @@ func (prwe *PrwExporter) export(ctx context.Context, tsMap map[string]*prompb.Ti
 	// Calls the helper function to convert and batch the TsMap to the desired format
 	requests, err := wrapAndBatchTimeSeries(tsMap)
 	if err != nil {
-		errs = append(errs, err)
+		errs = append(errs, consumererror.Permanent(err))
 		return errs
 	}
 
@@ -271,7 +271,7 @@ func (prwe *PrwExporter) export(ctx context.Context, tsMap map[string]*prompb.Ti
 			requestError := prwe.execute(ctx, req)
 			if requestError != nil {
 				mtx.Lock()
-				errs = append(errs, consumererror.Permanent(requestError))
+				errs = append(errs, requestError)
 				mtx.Unlock()
 			}
 			wg.Done()

--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -16,7 +16,6 @@ package prometheusremotewriteexporter
 
 import (
 	"errors"
-	"fmt"
 	"log"
 	"sort"
 	"strconv"
@@ -228,15 +227,10 @@ func batchTimeSeries(tsMap map[string]*prompb.TimeSeries) ([]*prompb.WriteReques
 	var tsArray []prompb.TimeSeries
 	sizeOfCurrentBatch := 0
 
-	fmt.Println("total metrics to process: " + fmt.Sprintf("%d", len(tsMap)))
-
 	for _, v := range tsMap {
 		sizeOfSeries := v.Size()
 
 		if sizeOfCurrentBatch+sizeOfSeries >= maxBatchByteSize {
-			fmt.Println("tsArray length: " + fmt.Sprintf("%d", len(tsArray)))
-			fmt.Println("sizeOfCurrentBatch: " + fmt.Sprintf("%d", sizeOfCurrentBatch))
-
 			wrapped := convertTimeseriesToRequest(tsArray)
 			requests = append(requests, wrapped)
 
@@ -249,9 +243,6 @@ func batchTimeSeries(tsMap map[string]*prompb.TimeSeries) ([]*prompb.WriteReques
 	}
 
 	if sizeOfCurrentBatch != 0 {
-		fmt.Println("tsArray length: " + fmt.Sprintf("%d", len(tsArray)))
-		fmt.Println("sizeOfCurrentBatch: " + fmt.Sprintf("%d", sizeOfCurrentBatch))
-
 		wrapped := convertTimeseriesToRequest(tsArray)
 		requests = append(requests, wrapped)
 	}
@@ -495,7 +486,7 @@ func addSingleDoubleSummaryDataPoint(pt *otlp.DoubleSummaryDataPoint, metric *ot
 }
 
 func convertTimeseriesToRequest(tsArray []prompb.TimeSeries) *prompb.WriteRequest {
-	// the remotewrite endpoint only needs the timeseries.
+	// the remote_write endpoint only requires the timeseries.
 	// otlp defines it's own way to handle metric metadata
 	return &prompb.WriteRequest{
 		Timeseries: tsArray,

--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -241,7 +241,7 @@ func wrapAndBatchTimeSeries(tsMap map[string]*prompb.TimeSeries) ([]*prompb.Writ
 				// Other parameters of the WriteRequest are unnecessary for our Export
 			}
 
-			if proto.Size(&wrapped) >= maxBatchByteSize || len(tsArray) >= maxBatchMetric {
+			if b := proto.Size(&wrapped); b >= maxBatchByteSize || len(tsArray) >= maxBatchMetric {
 				requests = append(requests, &wrapped)
 				tsArray = make([]prompb.TimeSeries, 0)
 

--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -242,10 +242,8 @@ func batchTimeSeries(tsMap map[string]*prompb.TimeSeries) ([]*prompb.WriteReques
 		sizeOfCurrentBatch += sizeOfSeries
 	}
 
-	if sizeOfCurrentBatch != 0 {
-		wrapped := convertTimeseriesToRequest(tsArray)
-		requests = append(requests, wrapped)
-	}
+	wrapped := convertTimeseriesToRequest(tsArray)
+	requests = append(requests, wrapped)
 
 	return requests, nil
 }


### PR DESCRIPTION
**Description:** 

Currently, there is no limit on the size of the remote_write export request to a Cortex instance. This could create problems if one Prometheus scrape produces an extreme amount of timeseries metrics. 

This PR creates a batch of concurrent requests where the max size of a request is 3MB and the max number of timeseries per request is 40,000.

**Testing:** 

* Unit tests were fixed
* Performance tests were done with 15000 Prometheus metrics (around 100k timeseries) per scrape. The first and last metric of each Prometheus metric type were all found.
