### PR TITLE
Migrate contrib-test workflow from CircleCI to GitHub Actions

### DIFF
--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -1,0 +1,23 @@
+name: contrib-tests
+on:
+  push:
+    branches: [master]
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+.*
+  pull_request:
+
+jobs:
+  contrib_tests:
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/go:1.15
+    steps:
+      - name: Setup Permissions
+        run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Run Contrib Tests
+        run: |
+          contrib_path=/tmp/opentelemetry-collector-contrib
+          git clone https://github.com/open-telemetry/opentelemetry-collector-contrib.git $contrib_path
+          make CONTRIB_PATH=$contrib_path check-contrib

--- a/receiver/kafkareceiver/factory_test.go
+++ b/receiver/kafkareceiver/factory_test.go
@@ -59,15 +59,15 @@ func TestCreateTraceReceiver_error(t *testing.T) {
 }
 
 func TestWithUnmarshallers(t *testing.T) {
-	cum := &customUnamarshaller{}
-	f := NewFactory(WithAddUnmarshallers(map[string]Unmarshaller{cum.Encoding(): cum}))
+	unmarshaller := &customUnamarshaller{}
+	f := NewFactory(WithAddUnmarshallers(map[string]Unmarshaller{unmarshaller.Encoding(): unmarshaller}))
 	cfg := createDefaultConfig().(*Config)
 	// disable contacting broker
 	cfg.Metadata.Full = false
 	cfg.ProtocolVersion = "2.0.0"
 
 	t.Run("custom_encoding", func(t *testing.T) {
-		cfg.Encoding = cum.Encoding()
+		cfg.Encoding = unmarshaller.Encoding()
 		exporter, err := f.CreateTracesReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, nil)
 		require.NoError(t, err)
 		require.NotNil(t, exporter)


### PR DESCRIPTION
## Which problem is this solving?
As part of [issue](https://github.com/open-telemetry/opentelemetry-collector/issues/1234), this pull request migrates the contrib_test workflow that was contained in the config.yml file to GitHub Actions.

## Migration Plan
I suggest having CircleCI and GitHub Actions jobs run in parallel for a few weeks. After the GitHub Actions jobs are running fine for a week or so and then remove the CircleCI workflows from config.yml

## Related PRs
A series of other PRs authored by @AzfaarQureshi and myself will be filed concurrently with this one migrating the build_and_test workflow in small chunks on the collector main repo and then on the collector-contrib repo.