### PR TITLE
GitHub Actions Cache build-tools and change all upload/download actions to @v1

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,7 +58,16 @@ jobs:
         with:
           path: /home/runner/go/pkg/mod
           key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('./go.mod') }}
+      - name: Restore tools binaries
+        id: tool-cache
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-tool-binaries
+        with:
+          path: /home/runner/go/bin
+          key: tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
       - name: Install tools
+        if: steps.tool-cache.outputs.cache-hit != 'true'
         run: make install-tools
       - name: split loadtest jobs
         id: splitloadtest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -108,7 +108,7 @@ jobs:
           path: /home/runner/go/pkg/mod
           key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('./go.mod') }}
       - name: Download tool binaries
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v1
         with:
           name: tool-binaries
           path: /home/runner/go/bin
@@ -142,7 +142,7 @@ jobs:
           path: /home/runner/go/pkg/mod
           key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('./go.mod') }}
       - name: Download tool binaries
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v1
         with:
           name: tool-binaries
           path: /home/runner/go/bin
@@ -171,7 +171,7 @@ jobs:
         with:
           go-version: 1.15
       - name: Download tool binaries
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v1
         with:
           name: tool-binaries
           path: /home/runner/go/bin
@@ -228,7 +228,7 @@ jobs:
         with:
           go-version: 1.15
       - name: Download tool binaries
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v1
         with:
           name: tool-binaries
           path: /home/runner/go/bin
@@ -279,12 +279,12 @@ jobs:
       - name: Install fpm and dependencies
         run: gem install --no-document fpm -v 1.11.0
       - name: Download tool binaries
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v1
         with:
           name: tool-binaries
           path: /home/runner/go/bin
       - name: Download collector binaries
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v1
         with:
           name: collector-binaries
           path: ./bin


### PR DESCRIPTION
Related to [issue](https://github.com/open-telemetry/opentelemetry-collector/issues/1234) and PR #2298, this PR is caching make tools and changing all the upload/download actions to @v1 