### PR TITLE
Edit type/func documentation in the consumer package

### DIFF
--- a/consumer/consumererror/permanent.go
+++ b/consumer/consumererror/permanent.go
@@ -25,7 +25,7 @@ type permanent struct {
 	err error
 }
 
-// Permanent wraps an error to indicate that it is a permanent error, i.e.: an
+// Permanent wraps an error to indicate that it is a permanent error, i.e. an
 // error that will be always returned if its source receives the same inputs.
 func Permanent(err error) error {
 	return permanent{err: err}
@@ -40,7 +40,7 @@ func (p permanent) Unwrap() error {
 	return p.err
 }
 
-// IsPermanent checks if an error was wrapped with the Permanent function, that
+// IsPermanent checks if an error was wrapped with the Permanent function, which
 // is used to indicate that a given error will always be returned in the case
 // that its sources receives the same input.
 func IsPermanent(err error) bool {

--- a/consumer/consumererror/signalerrors.go
+++ b/consumer/consumererror/signalerrors.go
@@ -35,7 +35,7 @@ func NewTraces(err error, failed pdata.Traces) error {
 	}
 }
 
-// AsTraces finds the first error in err's chain that can be assigned to target. If such an error is found
+// AsTraces finds the first error in err's chain that can be assigned to target. If such an error is found,
 // it is assigned to target and true is returned, otherwise false is returned.
 func AsTraces(err error, target *Traces) bool {
 	if err == nil {
@@ -69,7 +69,7 @@ func NewLogs(err error, failed pdata.Logs) error {
 	}
 }
 
-// AsLogs finds the first error in err's chain that can be assigned to target. If such an error is found
+// AsLogs finds the first error in err's chain that can be assigned to target. If such an error is found,
 // it is assigned to target and true is returned, otherwise false is returned.
 func AsLogs(err error, target *Logs) bool {
 	if err == nil {
@@ -103,7 +103,7 @@ func NewMetrics(err error, failed pdata.Metrics) error {
 	}
 }
 
-// AsMetrics finds the first error in err's chain that can be assigned to target. If such an error is found
+// AsMetrics finds the first error in err's chain that can be assigned to target. If such an error is found,
 // it is assigned to target and true is returned, otherwise false is returned.
 func AsMetrics(err error, target *Metrics) bool {
 	if err == nil {

--- a/consumer/consumerhelper/common.go
+++ b/consumer/consumerhelper/common.go
@@ -26,10 +26,10 @@ type baseConsumer struct {
 	capabilities consumer.Capabilities
 }
 
-// Option apply changes to internalOptions.
+// Option applies changes to internalOptions.
 type Option func(*baseConsumer)
 
-// WithCapabilities overrides the default GetCapabilities function for an processor.
+// WithCapabilities overrides the default GetCapabilities function for a processor.
 // The default GetCapabilities function returns mutable capabilities.
 func WithCapabilities(capabilities consumer.Capabilities) Option {
 	return func(o *baseConsumer) {

--- a/consumer/consumertest/base_consumer.go
+++ b/consumer/consumertest/base_consumer.go
@@ -20,6 +20,7 @@ import (
 
 type nonMutatingConsumer struct{}
 
+// Capabilities returns the base consumer capabilities.
 func (bc nonMutatingConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }

--- a/consumer/consumertest/consumer.go
+++ b/consumer/consumertest/consumer.go
@@ -22,9 +22,9 @@ import (
 )
 
 // Consumer is a convenience interface that implements all consumer interfaces.
-// It has a private function on it to forbid external users to implement it,
-// to allow us to add extra functions without breaking compatibility because
-// nobody else implements this interface.
+// It has a private function on it to forbid external users from implementing it
+// and, as a result, to allow us to add extra functions without breaking
+// compatibility.
 type Consumer interface {
 	// Capabilities to implement the base consumer functionality.
 	Capabilities() consumer.Capabilities

--- a/consumer/consumertest/err.go
+++ b/consumer/consumertest/err.go
@@ -39,7 +39,7 @@ func (er *errConsumer) ConsumeLogs(context.Context, pdata.Logs) error {
 	return er.err
 }
 
-// NewErr returns a Consumer that just drops all received data and returns no error.
+// NewErr returns a Consumer that just drops all received data and holds the input error.
 func NewErr(err error) Consumer {
 	return &errConsumer{err: err}
 }

--- a/consumer/consumertest/sink.go
+++ b/consumer/consumertest/sink.go
@@ -54,7 +54,7 @@ func (ste *TracesSink) AllTraces() []pdata.Traces {
 	return copyTraces
 }
 
-// SpansCount return the number of spans sent to this sink.
+// SpansCount returns the number of spans sent to this sink.
 func (ste *TracesSink) SpansCount() int {
 	ste.mu.Lock()
 	defer ste.mu.Unlock()
@@ -102,7 +102,7 @@ func (sme *MetricsSink) AllMetrics() []pdata.Metrics {
 	return copyMetrics
 }
 
-// MetricsCount return the number of metrics stored by this sink since last Reset.
+// MetricsCount returns the number of metrics stored by this sink since last Reset.
 func (sme *MetricsSink) MetricsCount() int {
 	sme.mu.Lock()
 	defer sme.mu.Unlock()
@@ -150,7 +150,7 @@ func (sle *LogsSink) AllLogs() []pdata.Logs {
 	return copyLogs
 }
 
-// LogRecordsCount return the number of log records stored by this sink since last Reset.
+// LogRecordsCount returns the number of log records stored by this sink since last Reset.
 func (sle *LogsSink) LogRecordsCount() int {
 	sle.mu.Lock()
 	defer sle.mu.Unlock()

--- a/consumer/pdata/common.go
+++ b/consumer/pdata/common.go
@@ -36,6 +36,7 @@ const (
 	AttributeValueTypeArray
 )
 
+// String returns the string representation of the AttributeValueType.
 func (avt AttributeValueType) String() string {
 	switch avt {
 	case AttributeValueTypeNull:

--- a/consumer/pdata/common.go
+++ b/consumer/pdata/common.go
@@ -70,7 +70,7 @@ func (avt AttributeValueType) String() string {
 //      _ := v.Type() // this will return AttributeValueTypeInt
 //   }
 //
-// Important: zero-initialized instance is not valid for use. All AttributeValue functions bellow must
+// Important: zero-initialized instance is not valid for use. All AttributeValue functions below must
 // be called only on instances that are created via NewAttributeValue+ functions.
 type AttributeValue struct {
 	orig *otlpcommon.AnyValue

--- a/consumer/pdata/common.go
+++ b/consumer/pdata/common.go
@@ -760,9 +760,9 @@ func (sm StringMap) Len() int {
 //
 // Example:
 //
-// it := sm.Range(func(k string, v StringValue) {
-//   ...
-// })
+//   it := sm.Range(func(k string, v StringValue) {
+//       ...
+//   })
 func (sm StringMap) Range(f func(k string, v string) bool) {
 	for i := range *sm.orig {
 		skv := &(*sm.orig)[i]
@@ -801,7 +801,7 @@ func (sm StringMap) get(k string) (*otlpcommon.StringKeyValue, bool) {
 
 // Sort sorts the entries in the StringMap so two instances can be compared.
 // Returns the same instance to allow nicer code like:
-// assert.EqualValues(t, expected.Sort(), actual.Sort())
+//   assert.EqualValues(t, expected.Sort(), actual.Sort())
 func (sm StringMap) Sort() StringMap {
 	sort.SliceStable(*sm.orig, func(i, j int) bool {
 		// Intention is to move the nil values at the end.

--- a/consumer/pdata/common.go
+++ b/consumer/pdata/common.go
@@ -608,9 +608,9 @@ func (am AttributeMap) Len() int {
 //
 // Example:
 //
-// it := sm.Range(func(k string, v AttributeValue) {
-//   ...
-// })
+//   it := sm.Range(func(k string, v AttributeValue) {
+//       ...
+//   })
 func (am AttributeMap) Range(f func(k string, v AttributeValue) bool) {
 	for i := range *am.orig {
 		kv := &(*am.orig)[i]

--- a/consumer/pdata/common.go
+++ b/consumer/pdata/common.go
@@ -363,7 +363,7 @@ func newAttributeMap(orig *[]otlpcommon.KeyValue) AttributeMap {
 // with values from the given map[string]string.
 //
 // Returns the same instance to allow nicer code like:
-// assert.EqualValues(t, NewAttributeMap().InitFromMap(map[string]AttributeValue{...}), actual)
+//   assert.EqualValues(t, NewAttributeMap().InitFromMap(map[string]AttributeValue{...}), actual)
 func (am AttributeMap) InitFromMap(attrMap map[string]AttributeValue) AttributeMap {
 	if len(attrMap) == 0 {
 		*am.orig = []otlpcommon.KeyValue(nil)
@@ -587,7 +587,7 @@ func (am AttributeMap) UpsertBool(k string, v bool) {
 
 // Sort sorts the entries in the AttributeMap so two instances can be compared.
 // Returns the same instance to allow nicer code like:
-// assert.EqualValues(t, expected.Sort(), actual.Sort())
+//   assert.EqualValues(t, expected.Sort(), actual.Sort())
 func (am AttributeMap) Sort() AttributeMap {
 	// Intention is to move the nil values at the end.
 	sort.SliceStable(*am.orig, func(i, j int) bool {
@@ -665,7 +665,7 @@ func newStringMap(orig *[]otlpcommon.StringKeyValue) StringMap {
 // with values from the given map[string]string.
 //
 // Returns the same instance to allow nicer code like:
-// assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{...}), actual)
+//   assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{...}), actual)
 func (sm StringMap) InitFromMap(attrMap map[string]string) StringMap {
 	if len(attrMap) == 0 {
 		*sm.orig = []otlpcommon.StringKeyValue(nil)

--- a/consumer/pdata/common.go
+++ b/consumer/pdata/common.go
@@ -66,7 +66,7 @@ func (avt AttributeValueType) String() string {
 //
 //   function f1(val AttributeValue) { val.SetIntVal(234) }
 //   function f2() {
-//   	v := NewAttributeValueString("a string")
+//      v := NewAttributeValueString("a string")
 //      f1(v)
 //      _ := v.Type() // this will return AttributeValueTypeInt
 //   }

--- a/consumer/pdata/common.go
+++ b/consumer/pdata/common.go
@@ -66,9 +66,9 @@ func (avt AttributeValueType) String() string {
 //
 //   function f1(val AttributeValue) { val.SetIntVal(234) }
 //   function f2() {
-//      v := NewAttributeValueString("a string")
-//      f1(v)
-//      _ := v.Type() // this will return AttributeValueTypeInt
+//       v := NewAttributeValueString("a string")
+//       f1(v)
+//       _ := v.Type() // this will return AttributeValueTypeInt
 //   }
 //
 // Important: zero-initialized instance is not valid for use. All AttributeValue functions below must

--- a/consumer/pdata/doc.go
+++ b/consumer/pdata/doc.go
@@ -13,20 +13,20 @@
 // limitations under the License.
 
 // Package pdata (pipeline data) implements data structures that represent telemetry data in-memory.
-// All data received is converted into this format and travels through the pipeline
-// in this format and that is converted from this format by exporters when sending.
+// All data received is converted into this format, travels through the pipeline
+// in this format, and is converted from this format by exporters when sending.
 //
 // Current implementation primarily uses OTLP ProtoBuf structs as the underlying data
 // structures for many of of the declared structs. We keep a pointer to OTLP protobuf
 // in the "orig" member field. This allows efficient translation to/from OTLP wire
-// protocol. Note that the underlying data structure is kept private so that in the
-// future we are free to make changes to it to make more optimal.
+// protocol. Note that the underlying data structure is kept private so that we are
+// free to make changes to it in the future.
 //
 // Most of internal data structures must be created via New* functions. Zero-initialized
-// structures in most cases are not valid (read comments for each struct to know if it
+// structures, in most cases, are not valid (read comments for each struct to know if that
 // is the case). This is a slight deviation from idiomatic Go to avoid unnecessary
 // pointer checks in dozens of functions which assume the invariant that "orig" member
-// is non-nil. Several structures also provide New*Slice functions that allows to create
+// is non-nil. Several structures also provide New*Slice functions that allow creating
 // more than one instance of the struct more efficiently instead of calling New*
 // repeatedly. Use it where appropriate.
 package pdata

--- a/consumer/pdata/generated_common.go
+++ b/consumer/pdata/generated_common.go
@@ -103,10 +103,10 @@ func (es AnyValueArray) Len() int {
 // At returns the element at the given index.
 //
 // This function is used mostly for iterating over all the values in the slice:
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     ... // Do something with the element
-// }
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       // Do something with the element
+//   }
 func (es AnyValueArray) At(ix int) AttributeValue {
 	return newAttributeValue(&(*es.orig)[ix])
 }

--- a/consumer/pdata/generated_common.go
+++ b/consumer/pdata/generated_common.go
@@ -71,7 +71,7 @@ func (ms InstrumentationLibrary) CopyTo(dest InstrumentationLibrary) {
 
 // AnyValueArray logically represents a slice of AttributeValue.
 //
-// This is a reference type, if passed by value and callee modifies it the
+// This is a reference type, if passed by value and callee modifies, it the
 // caller will see the modification.
 //
 // Must use NewAnyValueArray function to create new instances.

--- a/consumer/pdata/generated_common.go
+++ b/consumer/pdata/generated_common.go
@@ -131,12 +131,12 @@ func (es AnyValueArray) CopyTo(dest AnyValueArray) {
 // 2. If the newLen > len then (newLen - cap) empty elements will be appended to the slice.
 //
 // Here is how a new AnyValueArray can be initialized:
-// es := NewAnyValueArray()
-// es.Resize(4)
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     // Here should set all the values for e.
-// }
+//   es := NewAnyValueArray()
+//   es.Resize(4)
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       // Here should set all the values for e.
+//   }
 func (es AnyValueArray) Resize(newLen int) {
 	oldLen := len(*es.orig)
 	oldCap := cap(*es.orig)

--- a/consumer/pdata/generated_log.go
+++ b/consumer/pdata/generated_log.go
@@ -55,10 +55,10 @@ func (es ResourceLogsSlice) Len() int {
 // At returns the element at the given index.
 //
 // This function is used mostly for iterating over all the values in the slice:
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     ... // Do something with the element
-// }
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       ... // Do something with the element
+//   }
 func (es ResourceLogsSlice) At(ix int) ResourceLogs {
 	return newResourceLogs((*es.orig)[ix])
 }
@@ -88,12 +88,12 @@ func (es ResourceLogsSlice) CopyTo(dest ResourceLogsSlice) {
 // 2. If the newLen > len then (newLen - cap) empty elements will be appended to the slice.
 //
 // Here is how a new ResourceLogsSlice can be initialized:
-// es := NewResourceLogsSlice()
-// es.Resize(4)
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     // Here should set all the values for e.
-// }
+//   es := NewResourceLogsSlice()
+//   es.Resize(4)
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       // Here should set all the values for e.
+//   }
 func (es ResourceLogsSlice) Resize(newLen int) {
 	oldLen := len(*es.orig)
 	oldCap := cap(*es.orig)
@@ -235,10 +235,10 @@ func (es InstrumentationLibraryLogsSlice) Len() int {
 // At returns the element at the given index.
 //
 // This function is used mostly for iterating over all the values in the slice:
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     ... // Do something with the element
-// }
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       ... // Do something with the element
+//   }
 func (es InstrumentationLibraryLogsSlice) At(ix int) InstrumentationLibraryLogs {
 	return newInstrumentationLibraryLogs((*es.orig)[ix])
 }
@@ -268,12 +268,12 @@ func (es InstrumentationLibraryLogsSlice) CopyTo(dest InstrumentationLibraryLogs
 // 2. If the newLen > len then (newLen - cap) empty elements will be appended to the slice.
 //
 // Here is how a new InstrumentationLibraryLogsSlice can be initialized:
-// es := NewInstrumentationLibraryLogsSlice()
-// es.Resize(4)
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     // Here should set all the values for e.
-// }
+//   es := NewInstrumentationLibraryLogsSlice()
+//   es.Resize(4)
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       // Here should set all the values for e.
+//   }
 func (es InstrumentationLibraryLogsSlice) Resize(newLen int) {
 	oldLen := len(*es.orig)
 	oldCap := cap(*es.orig)
@@ -415,10 +415,10 @@ func (es LogSlice) Len() int {
 // At returns the element at the given index.
 //
 // This function is used mostly for iterating over all the values in the slice:
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     ... // Do something with the element
-// }
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       ... // Do something with the element
+//   }
 func (es LogSlice) At(ix int) LogRecord {
 	return newLogRecord((*es.orig)[ix])
 }
@@ -448,12 +448,12 @@ func (es LogSlice) CopyTo(dest LogSlice) {
 // 2. If the newLen > len then (newLen - cap) empty elements will be appended to the slice.
 //
 // Here is how a new LogSlice can be initialized:
-// es := NewLogSlice()
-// es.Resize(4)
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     // Here should set all the values for e.
-// }
+//   es := NewLogSlice()
+//   es.Resize(4)
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       // Here should set all the values for e.
+//   }
 func (es LogSlice) Resize(newLen int) {
 	oldLen := len(*es.orig)
 	oldCap := cap(*es.orig)

--- a/consumer/pdata/generated_metrics.go
+++ b/consumer/pdata/generated_metrics.go
@@ -2158,7 +2158,7 @@ func (es ValueAtQuantileSlice) RemoveIf(f func(ValueAtQuantile) bool) {
 	*es.orig = (*es.orig)[:newLen]
 }
 
-// ValueAtQuantile is a quantile value within a Summary data point
+// ValueAtQuantile is a quantile value within a Summary data point.
 //
 // This is a reference type, if passed by value and callee modifies it the
 // caller will see the modification.

--- a/consumer/pdata/generated_metrics.go
+++ b/consumer/pdata/generated_metrics.go
@@ -88,12 +88,12 @@ func (es ResourceMetricsSlice) CopyTo(dest ResourceMetricsSlice) {
 // 2. If the newLen > len then (newLen - cap) empty elements will be appended to the slice.
 //
 // Here is how a new ResourceMetricsSlice can be initialized:
-// es := NewResourceMetricsSlice()
-// es.Resize(4)
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     // Here should set all the values for e.
-// }
+//   es := NewResourceMetricsSlice()
+//   es.Resize(4)
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       // Here should set all the values for e.
+//   }
 func (es ResourceMetricsSlice) Resize(newLen int) {
 	oldLen := len(*es.orig)
 	oldCap := cap(*es.orig)
@@ -267,13 +267,13 @@ func (es InstrumentationLibraryMetricsSlice) CopyTo(dest InstrumentationLibraryM
 // 1. If the newLen <= len then equivalent with slice[0:newLen:cap].
 // 2. If the newLen > len then (newLen - cap) empty elements will be appended to the slice.
 //
-// Here is how a new InstrumentationLibraryMetricsSlice can be initialized:
-// es := NewInstrumentationLibraryMetricsSlice()
-// es.Resize(4)
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     // Here should set all the values for e.
-// }
+//   Here is how a new InstrumentationLibraryMetricsSlice can be initialized:
+//   es := NewInstrumentationLibraryMetricsSlice()
+//   es.Resize(4)
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       // Here should set all the values for e.
+//   }
 func (es InstrumentationLibraryMetricsSlice) Resize(newLen int) {
 	oldLen := len(*es.orig)
 	oldCap := cap(*es.orig)
@@ -448,12 +448,12 @@ func (es MetricSlice) CopyTo(dest MetricSlice) {
 // 2. If the newLen > len then (newLen - cap) empty elements will be appended to the slice.
 //
 // Here is how a new MetricSlice can be initialized:
-// es := NewMetricSlice()
-// es.Resize(4)
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     // Here should set all the values for e.
-// }
+//   es := NewMetricSlice()
+//   es.Resize(4)
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       // Here should set all the values for e.
+//   }
 func (es MetricSlice) Resize(newLen int) {
 	oldLen := len(*es.orig)
 	oldCap := cap(*es.orig)
@@ -941,12 +941,12 @@ func (es IntDataPointSlice) CopyTo(dest IntDataPointSlice) {
 // 2. If the newLen > len then (newLen - cap) empty elements will be appended to the slice.
 //
 // Here is how a new IntDataPointSlice can be initialized:
-// es := NewIntDataPointSlice()
-// es.Resize(4)
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     // Here should set all the values for e.
-// }
+//   es := NewIntDataPointSlice()
+//   es.Resize(4)
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       // Here should set all the values for e.
+//   }
 func (es IntDataPointSlice) Resize(newLen int) {
 	oldLen := len(*es.orig)
 	oldCap := cap(*es.orig)
@@ -1154,12 +1154,12 @@ func (es DoubleDataPointSlice) CopyTo(dest DoubleDataPointSlice) {
 // 2. If the newLen > len then (newLen - cap) empty elements will be appended to the slice.
 //
 // Here is how a new DoubleDataPointSlice can be initialized:
-// es := NewDoubleDataPointSlice()
-// es.Resize(4)
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     // Here should set all the values for e.
-// }
+//   es := NewDoubleDataPointSlice()
+//   es.Resize(4)
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       // Here should set all the values for e.
+//   }
 func (es DoubleDataPointSlice) Resize(newLen int) {
 	oldLen := len(*es.orig)
 	oldCap := cap(*es.orig)
@@ -1367,12 +1367,12 @@ func (es IntHistogramDataPointSlice) CopyTo(dest IntHistogramDataPointSlice) {
 // 2. If the newLen > len then (newLen - cap) empty elements will be appended to the slice.
 //
 // Here is how a new IntHistogramDataPointSlice can be initialized:
-// es := NewIntHistogramDataPointSlice()
-// es.Resize(4)
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     // Here should set all the values for e.
-// }
+//   es := NewIntHistogramDataPointSlice()
+//   es.Resize(4)
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       // Here should set all the values for e.
+//   }
 func (es IntHistogramDataPointSlice) Resize(newLen int) {
 	oldLen := len(*es.orig)
 	oldCap := cap(*es.orig)
@@ -1613,12 +1613,12 @@ func (es HistogramDataPointSlice) CopyTo(dest HistogramDataPointSlice) {
 // 2. If the newLen > len then (newLen - cap) empty elements will be appended to the slice.
 //
 // Here is how a new HistogramDataPointSlice can be initialized:
-// es := NewHistogramDataPointSlice()
-// es.Resize(4)
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     // Here should set all the values for e.
-// }
+//   es := NewHistogramDataPointSlice()
+//   es.Resize(4)
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       // Here should set all the values for e.
+//   }
 func (es HistogramDataPointSlice) Resize(newLen int) {
 	oldLen := len(*es.orig)
 	oldCap := cap(*es.orig)
@@ -1859,12 +1859,12 @@ func (es SummaryDataPointSlice) CopyTo(dest SummaryDataPointSlice) {
 // 2. If the newLen > len then (newLen - cap) empty elements will be appended to the slice.
 //
 // Here is how a new SummaryDataPointSlice can be initialized:
-// es := NewSummaryDataPointSlice()
-// es.Resize(4)
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     // Here should set all the values for e.
-// }
+//   es := NewSummaryDataPointSlice()
+//   es.Resize(4)
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       // Here should set all the values for e.
+//   }
 func (es SummaryDataPointSlice) Resize(newLen int) {
 	oldLen := len(*es.orig)
 	oldCap := cap(*es.orig)
@@ -2083,12 +2083,12 @@ func (es ValueAtQuantileSlice) CopyTo(dest ValueAtQuantileSlice) {
 // 2. If the newLen > len then (newLen - cap) empty elements will be appended to the slice.
 //
 // Here is how a new ValueAtQuantileSlice can be initialized:
-// es := NewValueAtQuantileSlice()
-// es.Resize(4)
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     // Here should set all the values for e.
-// }
+//   es := NewValueAtQuantileSlice()
+//   es.Resize(4)
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       // Here should set all the values for e.
+//   }
 func (es ValueAtQuantileSlice) Resize(newLen int) {
 	oldLen := len(*es.orig)
 	oldCap := cap(*es.orig)
@@ -2268,12 +2268,12 @@ func (es IntExemplarSlice) CopyTo(dest IntExemplarSlice) {
 // 2. If the newLen > len then (newLen - cap) empty elements will be appended to the slice.
 //
 // Here is how a new IntExemplarSlice can be initialized:
-// es := NewIntExemplarSlice()
-// es.Resize(4)
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     // Here should set all the values for e.
-// }
+//   es := NewIntExemplarSlice()
+//   es.Resize(4)
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       // Here should set all the values for e.
+//   }
 func (es IntExemplarSlice) Resize(newLen int) {
 	oldLen := len(*es.orig)
 	oldCap := cap(*es.orig)
@@ -2462,12 +2462,12 @@ func (es ExemplarSlice) CopyTo(dest ExemplarSlice) {
 // 2. If the newLen > len then (newLen - cap) empty elements will be appended to the slice.
 //
 // Here is how a new ExemplarSlice can be initialized:
-// es := NewExemplarSlice()
-// es.Resize(4)
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     // Here should set all the values for e.
-// }
+//   es := NewExemplarSlice()
+//   es.Resize(4)
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       // Here should set all the values for e.
+//   }
 func (es ExemplarSlice) Resize(newLen int) {
 	oldLen := len(*es.orig)
 	oldCap := cap(*es.orig)

--- a/consumer/pdata/generated_metrics.go
+++ b/consumer/pdata/generated_metrics.go
@@ -55,10 +55,10 @@ func (es ResourceMetricsSlice) Len() int {
 // At returns the element at the given index.
 //
 // This function is used mostly for iterating over all the values in the slice:
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     ... // Do something with the element
-// }
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       ... // Do something with the element
+//   }
 func (es ResourceMetricsSlice) At(ix int) ResourceMetrics {
 	return newResourceMetrics((*es.orig)[ix])
 }
@@ -235,10 +235,10 @@ func (es InstrumentationLibraryMetricsSlice) Len() int {
 // At returns the element at the given index.
 //
 // This function is used mostly for iterating over all the values in the slice:
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     ... // Do something with the element
-// }
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       ... // Do something with the element
+//   }
 func (es InstrumentationLibraryMetricsSlice) At(ix int) InstrumentationLibraryMetrics {
 	return newInstrumentationLibraryMetrics((*es.orig)[ix])
 }
@@ -415,10 +415,10 @@ func (es MetricSlice) Len() int {
 // At returns the element at the given index.
 //
 // This function is used mostly for iterating over all the values in the slice:
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     ... // Do something with the element
-// }
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       ... // Do something with the element
+//   }
 func (es MetricSlice) At(ix int) Metric {
 	return newMetric((*es.orig)[ix])
 }
@@ -908,10 +908,10 @@ func (es IntDataPointSlice) Len() int {
 // At returns the element at the given index.
 //
 // This function is used mostly for iterating over all the values in the slice:
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     ... // Do something with the element
-// }
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       ... // Do something with the element
+//   }
 func (es IntDataPointSlice) At(ix int) IntDataPoint {
 	return newIntDataPoint((*es.orig)[ix])
 }
@@ -1121,10 +1121,10 @@ func (es DoubleDataPointSlice) Len() int {
 // At returns the element at the given index.
 //
 // This function is used mostly for iterating over all the values in the slice:
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     ... // Do something with the element
-// }
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       ... // Do something with the element
+//   }
 func (es DoubleDataPointSlice) At(ix int) DoubleDataPoint {
 	return newDoubleDataPoint((*es.orig)[ix])
 }
@@ -1334,10 +1334,10 @@ func (es IntHistogramDataPointSlice) Len() int {
 // At returns the element at the given index.
 //
 // This function is used mostly for iterating over all the values in the slice:
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     ... // Do something with the element
-// }
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       ... // Do something with the element
+//   }
 func (es IntHistogramDataPointSlice) At(ix int) IntHistogramDataPoint {
 	return newIntHistogramDataPoint((*es.orig)[ix])
 }
@@ -1580,10 +1580,10 @@ func (es HistogramDataPointSlice) Len() int {
 // At returns the element at the given index.
 //
 // This function is used mostly for iterating over all the values in the slice:
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     ... // Do something with the element
-// }
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       ... // Do something with the element
+//   }
 func (es HistogramDataPointSlice) At(ix int) HistogramDataPoint {
 	return newHistogramDataPoint((*es.orig)[ix])
 }
@@ -1826,10 +1826,10 @@ func (es SummaryDataPointSlice) Len() int {
 // At returns the element at the given index.
 //
 // This function is used mostly for iterating over all the values in the slice:
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     ... // Do something with the element
-// }
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       ... // Do something with the element
+//   }
 func (es SummaryDataPointSlice) At(ix int) SummaryDataPoint {
 	return newSummaryDataPoint((*es.orig)[ix])
 }
@@ -2050,10 +2050,10 @@ func (es ValueAtQuantileSlice) Len() int {
 // At returns the element at the given index.
 //
 // This function is used mostly for iterating over all the values in the slice:
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     ... // Do something with the element
-// }
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       ... // Do something with the element
+//   }
 func (es ValueAtQuantileSlice) At(ix int) ValueAtQuantile {
 	return newValueAtQuantile((*es.orig)[ix])
 }
@@ -2240,10 +2240,10 @@ func (es IntExemplarSlice) Len() int {
 // At returns the element at the given index.
 //
 // This function is used mostly for iterating over all the values in the slice:
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     ... // Do something with the element
-// }
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       ... // Do something with the element
+//   }
 func (es IntExemplarSlice) At(ix int) IntExemplar {
 	return newIntExemplar(&(*es.orig)[ix])
 }
@@ -2434,10 +2434,10 @@ func (es ExemplarSlice) Len() int {
 // At returns the element at the given index.
 //
 // This function is used mostly for iterating over all the values in the slice:
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     ... // Do something with the element
-// }
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       ... // Do something with the element
+//   }
 func (es ExemplarSlice) At(ix int) Exemplar {
 	return newExemplar(&(*es.orig)[ix])
 }

--- a/consumer/pdata/generated_metrics.go
+++ b/consumer/pdata/generated_metrics.go
@@ -163,7 +163,7 @@ func (es ResourceMetricsSlice) RemoveIf(f func(ResourceMetrics) bool) {
 	*es.orig = (*es.orig)[:newLen]
 }
 
-// InstrumentationLibraryMetrics is a collection of metrics from a LibraryInstrumentation.
+// ResourceMetrics is a collection of metrics from a Resource.
 //
 // This is a reference type, if passed by value and callee modifies it the
 // caller will see the modification.

--- a/consumer/pdata/generated_resource.go
+++ b/consumer/pdata/generated_resource.go
@@ -21,7 +21,7 @@ import (
 	otlpresource "go.opentelemetry.io/collector/internal/data/protogen/resource/v1"
 )
 
-// Resource information.
+// Resource is a message representing the resource information.
 //
 // This is a reference type, if passed by value and callee modifies it the
 // caller will see the modification.

--- a/consumer/pdata/generated_trace.go
+++ b/consumer/pdata/generated_trace.go
@@ -1122,8 +1122,8 @@ func (ms SpanLink) CopyTo(dest SpanLink) {
 	dest.SetDroppedAttributesCount(ms.DroppedAttributesCount())
 }
 
-// SpanStatus is an optional final status for this span. Semantically when Status wasn't set
-// it is means span ended without errors and assume Status.Ok (code = 0).
+// SpanStatus is an optional final status for this span. Semantically, when Status was not
+// set, that means the span ended without errors and to assume Status.Ok (code = 0).
 //
 // This is a reference type, if passed by value and callee modifies it the
 // caller will see the modification.

--- a/consumer/pdata/generated_trace.go
+++ b/consumer/pdata/generated_trace.go
@@ -55,10 +55,10 @@ func (es ResourceSpansSlice) Len() int {
 // At returns the element at the given index.
 //
 // This function is used mostly for iterating over all the values in the slice:
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     ... // Do something with the element
-// }
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       ... // Do something with the element
+//   }
 func (es ResourceSpansSlice) At(ix int) ResourceSpans {
 	return newResourceSpans((*es.orig)[ix])
 }
@@ -88,12 +88,12 @@ func (es ResourceSpansSlice) CopyTo(dest ResourceSpansSlice) {
 // 2. If the newLen > len then (newLen - cap) empty elements will be appended to the slice.
 //
 // Here is how a new ResourceSpansSlice can be initialized:
-// es := NewResourceSpansSlice()
-// es.Resize(4)
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     // Here should set all the values for e.
-// }
+//   es := NewResourceSpansSlice()
+//   es.Resize(4)
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       // Here should set all the values for e.
+//   }
 func (es ResourceSpansSlice) Resize(newLen int) {
 	oldLen := len(*es.orig)
 	oldCap := cap(*es.orig)
@@ -235,10 +235,10 @@ func (es InstrumentationLibrarySpansSlice) Len() int {
 // At returns the element at the given index.
 //
 // This function is used mostly for iterating over all the values in the slice:
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     ... // Do something with the element
-// }
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       ... // Do something with the element
+//   }
 func (es InstrumentationLibrarySpansSlice) At(ix int) InstrumentationLibrarySpans {
 	return newInstrumentationLibrarySpans((*es.orig)[ix])
 }
@@ -268,12 +268,12 @@ func (es InstrumentationLibrarySpansSlice) CopyTo(dest InstrumentationLibrarySpa
 // 2. If the newLen > len then (newLen - cap) empty elements will be appended to the slice.
 //
 // Here is how a new InstrumentationLibrarySpansSlice can be initialized:
-// es := NewInstrumentationLibrarySpansSlice()
-// es.Resize(4)
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     // Here should set all the values for e.
-// }
+//   es := NewInstrumentationLibrarySpansSlice()
+//   es.Resize(4)
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       // Here should set all the values for e.
+//   }
 func (es InstrumentationLibrarySpansSlice) Resize(newLen int) {
 	oldLen := len(*es.orig)
 	oldCap := cap(*es.orig)
@@ -415,10 +415,10 @@ func (es SpanSlice) Len() int {
 // At returns the element at the given index.
 //
 // This function is used mostly for iterating over all the values in the slice:
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     ... // Do something with the element
-// }
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       ... // Do something with the element
+//   }
 func (es SpanSlice) At(ix int) Span {
 	return newSpan((*es.orig)[ix])
 }
@@ -448,12 +448,12 @@ func (es SpanSlice) CopyTo(dest SpanSlice) {
 // 2. If the newLen > len then (newLen - cap) empty elements will be appended to the slice.
 //
 // Here is how a new SpanSlice can be initialized:
-// es := NewSpanSlice()
-// es.Resize(4)
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     // Here should set all the values for e.
-// }
+//   es := NewSpanSlice()
+//   es.Resize(4)
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       // Here should set all the values for e.
+//   }
 func (es SpanSlice) Resize(newLen int) {
 	oldLen := len(*es.orig)
 	oldCap := cap(*es.orig)
@@ -729,10 +729,10 @@ func (es SpanEventSlice) Len() int {
 // At returns the element at the given index.
 //
 // This function is used mostly for iterating over all the values in the slice:
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     ... // Do something with the element
-// }
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       ... // Do something with the element
+//   }
 func (es SpanEventSlice) At(ix int) SpanEvent {
 	return newSpanEvent((*es.orig)[ix])
 }
@@ -762,12 +762,12 @@ func (es SpanEventSlice) CopyTo(dest SpanEventSlice) {
 // 2. If the newLen > len then (newLen - cap) empty elements will be appended to the slice.
 //
 // Here is how a new SpanEventSlice can be initialized:
-// es := NewSpanEventSlice()
-// es.Resize(4)
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     // Here should set all the values for e.
-// }
+//   es := NewSpanEventSlice()
+//   es.Resize(4)
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       // Here should set all the values for e.
+//   }
 func (es SpanEventSlice) Resize(newLen int) {
 	oldLen := len(*es.orig)
 	oldCap := cap(*es.orig)
@@ -937,10 +937,10 @@ func (es SpanLinkSlice) Len() int {
 // At returns the element at the given index.
 //
 // This function is used mostly for iterating over all the values in the slice:
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     ... // Do something with the element
-// }
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       ... // Do something with the element
+//   }
 func (es SpanLinkSlice) At(ix int) SpanLink {
 	return newSpanLink((*es.orig)[ix])
 }
@@ -970,12 +970,12 @@ func (es SpanLinkSlice) CopyTo(dest SpanLinkSlice) {
 // 2. If the newLen > len then (newLen - cap) empty elements will be appended to the slice.
 //
 // Here is how a new SpanLinkSlice can be initialized:
-// es := NewSpanLinkSlice()
-// es.Resize(4)
-// for i := 0; i < es.Len(); i++ {
-//     e := es.At(i)
-//     // Here should set all the values for e.
-// }
+//   es := NewSpanLinkSlice()
+//   es.Resize(4)
+//   for i := 0; i < es.Len(); i++ {
+//       e := es.At(i)
+//       // Here should set all the values for e.
+//   }
 func (es SpanLinkSlice) Resize(newLen int) {
 	oldLen := len(*es.orig)
 	oldCap := cap(*es.orig)

--- a/consumer/pdata/generated_trace.go
+++ b/consumer/pdata/generated_trace.go
@@ -524,7 +524,7 @@ func (es SpanSlice) RemoveIf(f func(Span) bool) {
 }
 
 // Span represents a single operation within a trace.
-// See Span definition in OTLP: https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/trace/v1/trace.proto#L37
+// See Span definition in OTLP: https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/trace/v1/trace.proto
 //
 // This is a reference type, if passed by value and callee modifies it the
 // caller will see the modification.
@@ -1046,7 +1046,7 @@ func (es SpanLinkSlice) RemoveIf(f func(SpanLink) bool) {
 }
 
 // SpanLink is a pointer from the current span to another span in the same trace or in a
-// different trace. See OTLP for link definition.
+// different trace. See Link definition in OTLP: https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/trace/v1/trace.proto
 //
 // This is a reference type, if passed by value and callee modifies it the
 // caller will see the modification.

--- a/consumer/pdata/generated_trace.go
+++ b/consumer/pdata/generated_trace.go
@@ -163,7 +163,7 @@ func (es ResourceSpansSlice) RemoveIf(f func(ResourceSpans) bool) {
 	*es.orig = (*es.orig)[:newLen]
 }
 
-// InstrumentationLibrarySpans is a collection of spans from a LibraryInstrumentation.
+// ResourceSpans is a collection of spans from a Resource.
 //
 // This is a reference type, if passed by value and callee modifies it the
 // caller will see the modification.

--- a/consumer/pdata/log.go
+++ b/consumer/pdata/log.go
@@ -135,4 +135,5 @@ const (
 	SeverityNumberFATAL4    = SeverityNumber(otlplogs.SeverityNumber_SEVERITY_NUMBER_FATAL4)
 )
 
+// String returns the string representation of the SeverityNumber.
 func (sn SeverityNumber) String() string { return otlplogs.SeverityNumber(sn).String() }

--- a/consumer/pdata/metric.go
+++ b/consumer/pdata/metric.go
@@ -166,6 +166,7 @@ const (
 	MetricDataTypeSummary
 )
 
+// String returns the string representation of the MetricDataType.
 func (mdt MetricDataType) String() string {
 	switch mdt {
 	case MetricDataTypeNone:

--- a/consumer/pdata/metric.go
+++ b/consumer/pdata/metric.go
@@ -38,10 +38,10 @@ func (at AggregationTemporality) String() string {
 	return otlpmetrics.AggregationTemporality(at).String()
 }
 
-// Metrics is an opaque interface that allows transition to the new internal Metrics data, but also facilitate the
-// transition to the new components especially for traces.
+// Metrics is an opaque interface that allows transition to the new internal Metrics data, but also facilitates the
+// transition to the new components, especially for traces.
 //
-// Outside of the core repository the metrics pipeline cannot be converted to the new model since data.MetricData is
+// Outside of the core repository, the metrics pipeline cannot be converted to the new model since data.MetricData is
 // part of the internal package.
 type Metrics struct {
 	orig *otlpcollectormetrics.ExportMetricsServiceRequest

--- a/consumer/pdata/trace.go
+++ b/consumer/pdata/trace.go
@@ -145,6 +145,7 @@ const (
 	StatusCodeError = StatusCode(otlptrace.Status_STATUS_CODE_ERROR)
 )
 
+// String returns the string representation of the StatusCode.
 func (sc StatusCode) String() string { return otlptrace.Status_StatusCode(sc).String() }
 
 // SetCode replaces the code associated with this SpanStatus.

--- a/consumer/pdata/trace.go
+++ b/consumer/pdata/trace.go
@@ -97,7 +97,7 @@ func (td Traces) ResourceSpans() ResourceSpansSlice {
 	return newResourceSpansSlice(&td.orig.ResourceSpans)
 }
 
-// TraceState in w3c-trace-context format: https://www.w3.org/TR/trace-context/#tracestate-header
+// TraceState is a message representing the tracestate in w3c-trace-context format: https://www.w3.org/TR/trace-context/#tracestate-header
 type TraceState string
 
 const (

--- a/consumer/simple/metrics.go
+++ b/consumer/simple/metrics.go
@@ -352,7 +352,7 @@ func (mb *SafeMetrics) AddHistogramRawDataPoint(name string, hist pdata.IntHisto
 	return mb
 }
 
-// AddDHistogramRawDataPoint wraps AddDHistogramRawDataPoint.
+// AddDHistogramRawDataPoint wraps Metrics.AddDHistogramRawDataPoint.
 func (mb *SafeMetrics) AddDHistogramRawDataPoint(name string, hist pdata.HistogramDataPoint) *SafeMetrics {
 	mb.Lock()
 	mb.Metrics.AddDHistogramRawDataPoint(name, hist)


### PR DESCRIPTION
**Description:** 
This PR updates the documentation of type and func declarations in the consumer package and all of its subpackages, with a focus on correcting grammar/spelling mistakes, cleaning up syntax to render the examples better, and updating incorrect references or wording.

**Link to tracking Issue:** 
Addresses part of issue [#3050](https://github.com/open-telemetry/opentelemetry-collector/issues/3050)