### PR TITLE
Automate triggering of doc-update on release

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -1,7 +1,7 @@
 name: Update OpenTelemetry Website Docs
 
 on:
-  # triggers only on a manual dispatch
+  release:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
**Description:** 
The doc-update action now triggers automatically on release, but can still be triggered manually if needed.


**Link to tracking Issue:** #3234


