### PR TITLE
Add support for port reuse by implementing multiplexing listener

### DIFF
--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -536,3 +536,25 @@ func tempSocketName(t *testing.T) string {
 	require.NoError(t, os.Remove(socket))
 	return socket
 }
+
+func TestGRPCPortReuse(t *testing.T) {
+	endpoint := "localhost: 2873"
+	t.Run("", func(t *testing.T) {
+		settings1 := createGRPCServerSettings(endpoint)
+		muxListener1, err := settings1.ToListener()
+		assert.NoError(t, err)
+		settings2 := createGRPCServerSettings(endpoint)
+		muxListener2, err := settings2.ToListener()
+		assert.NoError(t, err)
+		assert.Equal(t, muxListener1, muxListener2)
+	})
+}
+
+func createGRPCServerSettings(endpoint string) GRPCServerSettings {
+	return GRPCServerSettings{
+		NetAddr: confignet.NetAddr{
+			Endpoint: endpoint,
+			Transport: "tcp",
+		},
+	}
+}

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -482,3 +482,22 @@ func TestHttpHeaders(t *testing.T) {
 		})
 	}
 }
+
+func TestHTTPPortReuse(t *testing.T) {
+	endpoint := "localhost: 6489"
+	t.Run("", func(t *testing.T) {
+		settings1 := createHTTPServerSettings(endpoint)
+		muxListener1, err := settings1.ToListener()
+		assert.NoError(t, err)
+		settings2 := createHTTPServerSettings(endpoint)
+		muxListener2, err := settings2.ToListener()
+		assert.NoError(t, err)
+		assert.Equal(t, muxListener1, muxListener2)
+	})
+}
+
+func createHTTPServerSettings(endpoint string) HTTPServerSettings {
+	return HTTPServerSettings{
+		Endpoint: endpoint,
+	}
+}


### PR DESCRIPTION
**Description:**
OTel collector doesn't support port reuse currently. Error "address already in use" will occur if we reuse a port. This PR tries to solve this by adding a `multiplexing listener` field into the `HTTPServerSettings` and `GRPCServerSettings` as mentioned in the issue.