### PR TITLE
fix: revert all the renamed variables

### DIFF
--- a/component/experimental/component/factory.go
+++ b/component/experimental/component/factory.go
@@ -44,7 +44,7 @@ type ConfigSourceFactory interface {
 	// configuration and should not cause side-effects that prevent the creation
 	// of multiple instances of the Source.
 	// The object returned by this method needs to pass the checks implemented by
-	// 'configtest.CheckConfigStruct'. It is recommended to have such check in the
+	// 'configtest.ValidateConfig'. It is recommended to have such check in the
 	// tests of any implementation of the ConfigSourceFactory interface.
 	CreateDefaultConfig() config.Source
 

--- a/component/exporter.go
+++ b/component/exporter.go
@@ -70,7 +70,7 @@ type ExporterFactory interface {
 	// configuration and should not cause side-effects that prevent the creation
 	// of multiple instances of the Exporter.
 	// The object returned by this method needs to pass the checks implemented by
-	// 'configtest.CheckConfigStruct'. It is recommended to have these checks in the
+	// 'configtest.ValidateConfig'. It is recommended to have these checks in the
 	// tests of any implementation of the Factory interface.
 	CreateDefaultConfig() config.Exporter
 

--- a/component/extension.go
+++ b/component/extension.go
@@ -69,7 +69,7 @@ type ExtensionFactory interface {
 	// configuration and should not cause side-effects that prevent the creation
 	// of multiple instances of the Extension.
 	// The object returned by this method needs to pass the checks implemented by
-	// 'configtest.CheckConfigStruct'. It is recommended to have these checks in the
+	// 'configtest.ValidateConfig'. It is recommended to have these checks in the
 	// tests of any implementation of the Factory interface.
 	CreateDefaultConfig() config.Extension
 

--- a/component/processor.go
+++ b/component/processor.go
@@ -75,7 +75,7 @@ type ProcessorFactory interface {
 	// configuration and should not cause side-effects that prevent the creation
 	// of multiple instances of the Processor.
 	// The object returned by this method needs to pass the checks implemented by
-	// 'configtest.CheckConfigStruct'. It is recommended to have these checks in the
+	// 'configtest.ValidateConfig'. It is recommended to have these checks in the
 	// tests of any implementation of the Factory interface.
 	CreateDefaultConfig() config.Processor
 

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -79,7 +79,7 @@ type ReceiverFactory interface {
 	// configuration and should not cause side-effects that prevent the creation
 	// of multiple instances of the Receiver.
 	// The object returned by this method needs to pass the checks implemented by
-	// 'configtest.CheckConfigStruct'. It is recommended to have these checks in the
+	// 'configtest.ValidateConfig'. It is recommended to have these checks in the
 	// tests of any implementation of the Factory interface.
 	CreateDefaultConfig() config.Receiver
 

--- a/config/configcheck/configcheck.go
+++ b/config/configcheck/configcheck.go
@@ -20,28 +20,28 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumererror"
 )
 
-// CheckConfigStructFromFactories checks if all configurations for the given factories
+// ValidateConfigFromFactories checks if all configurations for the given factories
 // are satisfying the patterns used by the collector.
-func CheckConfigStructFromFactories(factories component.Factories) error {
+func ValidateConfigFromFactories(factories component.Factories) error {
 	var errs []error
 
 	for _, factory := range factories.Receivers {
-		if err := configtest.CheckConfigStruct(factory.CreateDefaultConfig()); err != nil {
+		if err := configtest.ValidateConfig(factory.CreateDefaultConfig()); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	for _, factory := range factories.Processors {
-		if err := configtest.CheckConfigStruct(factory.CreateDefaultConfig()); err != nil {
+		if err := configtest.ValidateConfig(factory.CreateDefaultConfig()); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	for _, factory := range factories.Exporters {
-		if err := configtest.CheckConfigStruct(factory.CreateDefaultConfig()); err != nil {
+		if err := configtest.ValidateConfig(factory.CreateDefaultConfig()); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	for _, factory := range factories.Extensions {
-		if err := configtest.CheckConfigStruct(factory.CreateDefaultConfig()); err != nil {
+		if err := configtest.ValidateConfig(factory.CreateDefaultConfig()); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/config/configcheck/configcheck_test.go
+++ b/config/configcheck/configcheck_test.go
@@ -25,15 +25,15 @@ import (
 	"go.opentelemetry.io/collector/service/defaultcomponents"
 )
 
-func TestCheckConfigStructFromFactories_Success(t *testing.T) {
+func TestValidateConfigFromFactories_Success(t *testing.T) {
 	factories, err := defaultcomponents.Components()
 	require.NoError(t, err)
 
-	err = CheckConfigStructFromFactories(factories)
+	err = ValidateConfigFromFactories(factories)
 	require.NoError(t, err)
 }
 
-func TestCheckConfigStructFromFactories_Failure(t *testing.T) {
+func TestValidateConfigFromFactories_Failure(t *testing.T) {
 	factories, err := defaultcomponents.Components()
 	require.NoError(t, err)
 
@@ -41,7 +41,7 @@ func TestCheckConfigStructFromFactories_Failure(t *testing.T) {
 	f := &badConfigExtensionFactory{}
 	factories.Extensions[f.Type()] = f
 
-	err = CheckConfigStructFromFactories(factories)
+	err = ValidateConfigFromFactories(factories)
 	require.Error(t, err)
 }
 

--- a/config/configtest/configtest_test.go
+++ b/config/configtest/configtest_test.go
@@ -82,15 +82,15 @@ func TestLoadConfigAndValidate(t *testing.T) {
 	assert.Equal(t, cfg, cfgValidate)
 }
 
-func TestCheckConfigStructPointerAndValue(t *testing.T) {
+func TestValidateConfigPointerAndValue(t *testing.T) {
 	config := struct {
 		SomeFiled string `mapstructure:"test"`
 	}{}
-	assert.NoError(t, CheckConfigStruct(config))
-	assert.NoError(t, CheckConfigStruct(&config))
+	assert.NoError(t, ValidateConfig(config))
+	assert.NoError(t, ValidateConfig(&config))
 }
 
-func TestCheckConfigStruct(t *testing.T) {
+func TestValidateConfig(t *testing.T) {
 	type BadConfigTag struct {
 		BadTagField int `mapstructure:"test-dash"`
 	}
@@ -206,7 +206,7 @@ func TestCheckConfigStruct(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := CheckConfigStruct(tt.config)
+			err := ValidateConfig(tt.config)
 			if tt.wantErrMsgSubStr == "" {
 				assert.NoError(t, err)
 			} else {

--- a/exporter/loggingexporter/factory_test.go
+++ b/exporter/loggingexporter/factory_test.go
@@ -28,7 +28,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
-	assert.NoError(t, configtest.CheckConfigStruct(cfg))
+	assert.NoError(t, configtest.ValidateConfig(cfg))
 }
 
 func TestCreateMetricsExporter(t *testing.T) {

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -35,7 +35,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
-	assert.NoError(t, configtest.CheckConfigStruct(cfg))
+	assert.NoError(t, configtest.ValidateConfig(cfg))
 	ocfg, ok := factory.CreateDefaultConfig().(*Config)
 	assert.True(t, ok)
 	assert.Equal(t, ocfg.RetrySettings, exporterhelper.DefaultRetrySettings())

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -34,7 +34,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
-	assert.NoError(t, configtest.CheckConfigStruct(cfg))
+	assert.NoError(t, configtest.ValidateConfig(cfg))
 	ocfg, ok := factory.CreateDefaultConfig().(*Config)
 	assert.True(t, ok)
 	assert.Equal(t, ocfg.HTTPClientSettings.Endpoint, "")

--- a/extension/ballastextension/factory_test.go
+++ b/extension/ballastextension/factory_test.go
@@ -30,7 +30,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig()
 	assert.Equal(t, &Config{ExtensionSettings: config.NewExtensionSettings(config.NewID(typeStr))}, cfg)
 
-	assert.NoError(t, configtest.CheckConfigStruct(cfg))
+	assert.NoError(t, configtest.ValidateConfig(cfg))
 	ext, err := createExtension(context.Background(), componenttest.NewNopExtensionCreateSettings(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, ext)

--- a/extension/zpagesextension/factory_test.go
+++ b/extension/zpagesextension/factory_test.go
@@ -38,7 +38,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 	},
 		cfg)
 
-	assert.NoError(t, configtest.CheckConfigStruct(cfg))
+	assert.NoError(t, configtest.ValidateConfig(cfg))
 	ext, err := createExtension(context.Background(), componenttest.NewNopExtensionCreateSettings(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, ext)

--- a/processor/batchprocessor/config_test.go
+++ b/processor/batchprocessor/config_test.go
@@ -56,7 +56,7 @@ func TestLoadConfig(t *testing.T) {
 		})
 }
 
-func TestCheckConfigStruct_DefaultBatchMaxSize(t *testing.T) {
+func TestValidateConfig_DefaultBatchMaxSize(t *testing.T) {
 	cfg := &Config{
 		ProcessorSettings: config.NewProcessorSettings(config.NewIDWithName(typeStr, "2")),
 		SendBatchSize:     100,
@@ -65,7 +65,7 @@ func TestCheckConfigStruct_DefaultBatchMaxSize(t *testing.T) {
 	assert.NoError(t, cfg.Validate())
 }
 
-func TestCheckConfigStruct_ValidBatchSizes(t *testing.T) {
+func TestValidateConfig_ValidBatchSizes(t *testing.T) {
 	cfg := &Config{
 		ProcessorSettings: config.NewProcessorSettings(config.NewIDWithName(typeStr, "2")),
 		SendBatchSize:     100,
@@ -75,7 +75,7 @@ func TestCheckConfigStruct_ValidBatchSizes(t *testing.T) {
 
 }
 
-func TestCheckConfigStruct_InvalidBatchSize(t *testing.T) {
+func TestValidateConfig_InvalidBatchSize(t *testing.T) {
 	cfg := &Config{
 		ProcessorSettings: config.NewProcessorSettings(config.NewIDWithName(typeStr, "2")),
 		SendBatchSize:     1000,

--- a/processor/batchprocessor/factory_test.go
+++ b/processor/batchprocessor/factory_test.go
@@ -29,7 +29,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
-	assert.NoError(t, configtest.CheckConfigStruct(cfg))
+	assert.NoError(t, configtest.ValidateConfig(cfg))
 }
 
 func TestCreateProcessor(t *testing.T) {

--- a/processor/memorylimiter/factory_test.go
+++ b/processor/memorylimiter/factory_test.go
@@ -33,7 +33,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
-	assert.NoError(t, configtest.CheckConfigStruct(cfg))
+	assert.NoError(t, configtest.ValidateConfig(cfg))
 }
 
 func TestCreateProcessor(t *testing.T) {

--- a/receiver/otlpreceiver/factory_test.go
+++ b/receiver/otlpreceiver/factory_test.go
@@ -36,7 +36,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
-	assert.NoError(t, configtest.CheckConfigStruct(cfg))
+	assert.NoError(t, configtest.ValidateConfig(cfg))
 }
 
 func TestCreateReceiver(t *testing.T) {

--- a/service/collector.go
+++ b/service/collector.go
@@ -98,7 +98,7 @@ type Collector struct {
 
 // New creates and returns a new instance of Collector.
 func New(set CollectorSettings) (*Collector, error) {
-	if err := configcheck.CheckConfigStructFromFactories(set.Factories); err != nil {
+	if err := configcheck.ValidateConfigFromFactories(set.Factories); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
**Description:** 
This PR reverts all the renamed function names and variables for movevalidateconfig branch since the issue is only about moving the code.

**Link to tracking Issue:** 
#3875