### PR TITLE
fix: rename ValidateConfig to CheckConfigStruct

### DIFF
--- a/component/experimental/component/factory.go
+++ b/component/experimental/component/factory.go
@@ -44,7 +44,7 @@ type ConfigSourceFactory interface {
 	// configuration and should not cause side-effects that prevent the creation
 	// of multiple instances of the Source.
 	// The object returned by this method needs to pass the checks implemented by
-	// 'configtest.ValidateConfig'. It is recommended to have such check in the
+	// 'configtest.CheckConfigStruct'. It is recommended to have such check in the
 	// tests of any implementation of the ConfigSourceFactory interface.
 	CreateDefaultConfig() config.Source
 

--- a/component/exporter.go
+++ b/component/exporter.go
@@ -70,7 +70,7 @@ type ExporterFactory interface {
 	// configuration and should not cause side-effects that prevent the creation
 	// of multiple instances of the Exporter.
 	// The object returned by this method needs to pass the checks implemented by
-	// 'configtest.ValidateConfig'. It is recommended to have these checks in the
+	// 'configtest.CheckConfigStruct'. It is recommended to have these checks in the
 	// tests of any implementation of the Factory interface.
 	CreateDefaultConfig() config.Exporter
 

--- a/component/extension.go
+++ b/component/extension.go
@@ -69,7 +69,7 @@ type ExtensionFactory interface {
 	// configuration and should not cause side-effects that prevent the creation
 	// of multiple instances of the Extension.
 	// The object returned by this method needs to pass the checks implemented by
-	// 'configtest.ValidateConfig'. It is recommended to have these checks in the
+	// 'configtest.CheckConfigStruct'. It is recommended to have these checks in the
 	// tests of any implementation of the Factory interface.
 	CreateDefaultConfig() config.Extension
 

--- a/component/processor.go
+++ b/component/processor.go
@@ -75,7 +75,7 @@ type ProcessorFactory interface {
 	// configuration and should not cause side-effects that prevent the creation
 	// of multiple instances of the Processor.
 	// The object returned by this method needs to pass the checks implemented by
-	// 'configtest.ValidateConfig'. It is recommended to have these checks in the
+	// 'configtest.CheckConfigStruct'. It is recommended to have these checks in the
 	// tests of any implementation of the Factory interface.
 	CreateDefaultConfig() config.Processor
 

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -79,7 +79,7 @@ type ReceiverFactory interface {
 	// configuration and should not cause side-effects that prevent the creation
 	// of multiple instances of the Receiver.
 	// The object returned by this method needs to pass the checks implemented by
-	// 'configtest.ValidateConfig'. It is recommended to have these checks in the
+	// 'configtest.CheckConfigStruct'. It is recommended to have these checks in the
 	// tests of any implementation of the Factory interface.
 	CreateDefaultConfig() config.Receiver
 

--- a/config/configcheck/configcheck.go
+++ b/config/configcheck/configcheck.go
@@ -26,22 +26,22 @@ func ValidateConfigFromFactories(factories component.Factories) error {
 	var errs []error
 
 	for _, factory := range factories.Receivers {
-		if err := configtest.ValidateConfig(factory.CreateDefaultConfig()); err != nil {
+		if err := configtest.CheckConfigStruct(factory.CreateDefaultConfig()); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	for _, factory := range factories.Processors {
-		if err := configtest.ValidateConfig(factory.CreateDefaultConfig()); err != nil {
+		if err := configtest.CheckConfigStruct(factory.CreateDefaultConfig()); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	for _, factory := range factories.Exporters {
-		if err := configtest.ValidateConfig(factory.CreateDefaultConfig()); err != nil {
+		if err := configtest.CheckConfigStruct(factory.CreateDefaultConfig()); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	for _, factory := range factories.Extensions {
-		if err := configtest.ValidateConfig(factory.CreateDefaultConfig()); err != nil {
+		if err := configtest.CheckConfigStruct(factory.CreateDefaultConfig()); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/config/configtest/configtest.go
+++ b/config/configtest/configtest.go
@@ -50,12 +50,12 @@ func LoadConfigAndValidate(fileName string, factories component.Factories) (*con
 	return cfg, cfg.Validate()
 }
 
-// ValidateConfig enforces that given configuration object is following the patterns
+// CheckConfigStruct enforces that given configuration object is following the patterns
 // used by the collector. This ensures consistency between different implementations
 // of components and extensions. It is recommended for implementers of components
 // to call this function on their tests passing the default configuration of the
 // component factory.
-func ValidateConfig(config interface{}) error {
+func CheckConfigStruct(config interface{}) error {
 	t := reflect.TypeOf(config)
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()

--- a/config/configtest/configtest_test.go
+++ b/config/configtest/configtest_test.go
@@ -86,8 +86,8 @@ func TestValidateConfigPointerAndValue(t *testing.T) {
 	config := struct {
 		SomeFiled string `mapstructure:"test"`
 	}{}
-	assert.NoError(t, ValidateConfig(config))
-	assert.NoError(t, ValidateConfig(&config))
+	assert.NoError(t, CheckConfigStruct(config))
+	assert.NoError(t, CheckConfigStruct(&config))
 }
 
 func TestValidateConfig(t *testing.T) {
@@ -206,7 +206,7 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateConfig(tt.config)
+			err := CheckConfigStruct(tt.config)
 			if tt.wantErrMsgSubStr == "" {
 				assert.NoError(t, err)
 			} else {

--- a/exporter/loggingexporter/factory_test.go
+++ b/exporter/loggingexporter/factory_test.go
@@ -28,7 +28,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
-	assert.NoError(t, configtest.ValidateConfig(cfg))
+	assert.NoError(t, configtest.CheckConfigStruct(cfg))
 }
 
 func TestCreateMetricsExporter(t *testing.T) {

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -35,7 +35,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
-	assert.NoError(t, configtest.ValidateConfig(cfg))
+	assert.NoError(t, configtest.CheckConfigStruct(cfg))
 	ocfg, ok := factory.CreateDefaultConfig().(*Config)
 	assert.True(t, ok)
 	assert.Equal(t, ocfg.RetrySettings, exporterhelper.DefaultRetrySettings())

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -34,7 +34,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
-	assert.NoError(t, configtest.ValidateConfig(cfg))
+	assert.NoError(t, configtest.CheckConfigStruct(cfg))
 	ocfg, ok := factory.CreateDefaultConfig().(*Config)
 	assert.True(t, ok)
 	assert.Equal(t, ocfg.HTTPClientSettings.Endpoint, "")

--- a/extension/ballastextension/factory_test.go
+++ b/extension/ballastextension/factory_test.go
@@ -30,7 +30,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig()
 	assert.Equal(t, &Config{ExtensionSettings: config.NewExtensionSettings(config.NewID(typeStr))}, cfg)
 
-	assert.NoError(t, configtest.ValidateConfig(cfg))
+	assert.NoError(t, configtest.CheckConfigStruct(cfg))
 	ext, err := createExtension(context.Background(), componenttest.NewNopExtensionCreateSettings(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, ext)

--- a/extension/zpagesextension/factory_test.go
+++ b/extension/zpagesextension/factory_test.go
@@ -38,7 +38,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 	},
 		cfg)
 
-	assert.NoError(t, configtest.ValidateConfig(cfg))
+	assert.NoError(t, configtest.CheckConfigStruct(cfg))
 	ext, err := createExtension(context.Background(), componenttest.NewNopExtensionCreateSettings(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, ext)

--- a/processor/batchprocessor/factory_test.go
+++ b/processor/batchprocessor/factory_test.go
@@ -29,7 +29,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
-	assert.NoError(t, configtest.ValidateConfig(cfg))
+	assert.NoError(t, configtest.CheckConfigStruct(cfg))
 }
 
 func TestCreateProcessor(t *testing.T) {

--- a/processor/memorylimiter/factory_test.go
+++ b/processor/memorylimiter/factory_test.go
@@ -33,7 +33,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
-	assert.NoError(t, configtest.ValidateConfig(cfg))
+	assert.NoError(t, configtest.CheckConfigStruct(cfg))
 }
 
 func TestCreateProcessor(t *testing.T) {

--- a/receiver/otlpreceiver/factory_test.go
+++ b/receiver/otlpreceiver/factory_test.go
@@ -36,7 +36,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
-	assert.NoError(t, configtest.ValidateConfig(cfg))
+	assert.NoError(t, configtest.CheckConfigStruct(cfg))
 }
 
 func TestCreateReceiver(t *testing.T) {


### PR DESCRIPTION
**Description:**
This PR changes the name ValidateConfig() to CheckConfigStruct()

**Link to tracking Issue:**
issue 3875