### PR TITLE
fix: rename test names

### DIFF
--- a/config/configtest/configtest_test.go
+++ b/config/configtest/configtest_test.go
@@ -82,7 +82,7 @@ func TestLoadConfigAndValidate(t *testing.T) {
 	assert.Equal(t, cfg, cfgValidate)
 }
 
-func TestValidateConfigPointerAndValue(t *testing.T) {
+func TestCheckConfigStructPointerAndValue(t *testing.T) {
 	config := struct {
 		SomeFiled string `mapstructure:"test"`
 	}{}
@@ -90,7 +90,7 @@ func TestValidateConfigPointerAndValue(t *testing.T) {
 	assert.NoError(t, ValidateConfig(&config))
 }
 
-func TestValidateConfig(t *testing.T) {
+func TestCheckConfigStruct(t *testing.T) {
 	type BadConfigTag struct {
 		BadTagField int `mapstructure:"test-dash"`
 	}


### PR DESCRIPTION
**Description:**
This PR changes the name of two tests, "TestValidateConfigPointerAndValue" and "TestValidateConfig" into "TestCheckConfigStructPointerAndValue" and "TestCheckConfigStruct", respectively.

**Link to tracking Issue:**
issue 3875